### PR TITLE
Segment builder tool system

### DIFF
--- a/src/main/java/com/clarkson/sot/commands/BuilderMode.java
+++ b/src/main/java/com/clarkson/sot/commands/BuilderMode.java
@@ -1,0 +1,56 @@
+package com.clarkson.sot.commands;
+
+/**
+ * All available modes for the segment builder tool.
+ * Switched via /sotmode <mode>.
+ */
+public enum BuilderMode {
+
+    ENTRY_POINT(
+        "Entry Point",
+        "Right-click a wall face to place. Right-click existing marker to rotate."
+    ),
+    VAULT_DOOR(
+        "Vault Door",
+        "Right-click two opposite air corners to define the vault door opening."
+    ),
+    GATE(
+        "Gate",
+        "Right-click two opposite air corners to define the gate opening."
+    ),
+    LEVER(
+        "Lever",
+        "Right-click any block face to mark the gate lever location."
+    ),
+    SAND_SPAWN(
+        "Sand Spawn",
+        "Right-click any block face to mark a sand spawn location."
+    ),
+    SAND_SACRIFICE(
+        "Sand Sacrifice",
+        "Right-click any block face to mark a sand sacrifice altar."
+    ),
+    COIN_SPAWN(
+        "Coin Spawn",
+        "Right-click any block face to mark a coin spawn location."
+    ),
+    ITEM_SPAWN(
+        "Item Spawn",
+        "Right-click any block face to mark an item spawn location."
+    ),
+    MOB_SPAWNER(
+        "Mob Spawner",
+        "Right-click any block face to mark a mob spawner location."
+    );
+
+    private final String displayName;
+    private final String hint;
+
+    BuilderMode(String displayName, String hint) {
+        this.displayName = displayName;
+        this.hint = hint;
+    }
+
+    public String getDisplayName() { return displayName; }
+    public String getHint() { return hint; }
+}

--- a/src/main/java/com/clarkson/sot/commands/GiveBuilderToolCommand.java
+++ b/src/main/java/com/clarkson/sot/commands/GiveBuilderToolCommand.java
@@ -1,0 +1,65 @@
+package com.clarkson.sot.commands;
+
+import com.clarkson.sot.main.SoT;
+import com.clarkson.sot.utils.SegmentBuilderKeys;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * /sotbuilder — gives the player the master segment builder tool.
+ * Mode is switched separately via /sotmode.
+ */
+public class GiveBuilderToolCommand implements CommandExecutor {
+
+    private static final String TOOL_ID = "SEGMENT_BUILDER";
+
+    private final SoT plugin;
+    private final SegmentBuilderKeys keys;
+
+    public GiveBuilderToolCommand(SoT plugin, SegmentBuilderKeys keys) {
+        this.plugin = plugin;
+        this.keys = keys;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(Component.text("This command can only be run by a player.", NamedTextColor.RED));
+            return true;
+        }
+        if (!player.hasPermission("sot.builder.tool")) {
+            player.sendMessage(Component.text("You don't have permission to use this command.", NamedTextColor.RED));
+            return true;
+        }
+
+        ItemStack tool = new ItemStack(Material.BLAZE_ROD);
+        ItemMeta meta = tool.getItemMeta();
+        meta.displayName(Component.text("Segment Builder", NamedTextColor.GOLD));
+        meta.lore(List.of(
+            Component.text("Mode: ENTRY_POINT", NamedTextColor.YELLOW),
+            Component.text("Right-click to place  |  Left-click to remove", NamedTextColor.GRAY),
+            Component.text("Use /sotmode <mode> to switch", NamedTextColor.DARK_GRAY)
+        ));
+        meta.getPersistentDataContainer().set(keys.TOOL_TYPE, PersistentDataType.STRING, TOOL_ID);
+        tool.setItemMeta(meta);
+
+        player.getInventory().addItem(tool);
+        player.sendMessage(Component.text("Segment Builder tool given. Use ", NamedTextColor.GREEN)
+            .append(Component.text("/sotmode <mode>", NamedTextColor.YELLOW))
+            .append(Component.text(" to switch modes.", NamedTextColor.GREEN)));
+        return true;
+    }
+}

--- a/src/main/java/com/clarkson/sot/commands/SaveSegmentCommand.java
+++ b/src/main/java/com/clarkson/sot/commands/SaveSegmentCommand.java
@@ -1,221 +1,322 @@
 package com.clarkson.sot.commands;
 
-import com.clarkson.sot.dungeon.segment.SegmentType;
+import com.clarkson.sot.dungeon.segment.Direction;
 import com.clarkson.sot.dungeon.segment.Segment;
+import com.clarkson.sot.dungeon.segment.SegmentBound;
+import com.clarkson.sot.dungeon.segment.SegmentType;
 import com.clarkson.sot.dungeon.segment.PlacedSegment;
-import com.clarkson.sot.main.SoT; // Your main plugin class
+import com.clarkson.sot.events.ToolListener;
+import com.clarkson.sot.main.SoT;
+import com.clarkson.sot.utils.SegmentBuilderKeys;
 import com.clarkson.sot.utils.StructureSaver;
 
-// WorldEdit imports
+import com.sk89q.worldedit.IncompleteRegionException;
+import com.sk89q.worldedit.LocalSession;
+import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.session.SessionManager;
-// Removed SessionOwner import as it's unused
-import com.sk89q.worldedit.IncompleteRegionException;
-import com.sk89q.worldedit.LocalSession;
-import com.sk89q.worldedit.WorldEdit;
 
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 
 import org.bukkit.Bukkit;
-// Removed: import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.BlockDisplay;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.util.BoundingBox;
 import org.jetbrains.annotations.NotNull;
 
-// Adventure API Imports
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
-
-import java.util.ArrayList; // For empty lists
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
-import java.util.stream.Collectors; // For joining segment type names
+import java.util.stream.Collectors;
 
 /**
- * Command to save a selected structure as a new Segment template.
- * Usage: /sotsavesegment <name> <type> <schematic_filename> [totalCoins]
- * NOTE: This is a basic example. It does NOT handle parsing entry points,
- * spawn points, or vault/key locations from arguments, which is complex.
- * An in-game marking tool is recommended for those features.
+ * /sotsavesegment <name> <type> [totalCoins]
+ *
+ * Reads all BUILD_MARKER_TAG entities within the current WorldEdit selection,
+ * converts their absolute positions to relative offsets, and saves the segment.
+ * Schematic filename is auto-generated as <name>.schem.
  */
 public class SaveSegmentCommand implements CommandExecutor {
 
     private final SoT plugin;
     private final StructureSaver structureSaver;
     private final WorldEditPlugin worldEdit;
+    private final SegmentBuilderKeys keys;
 
-    public SaveSegmentCommand(SoT plugin) {
+    public SaveSegmentCommand(SoT plugin, SegmentBuilderKeys keys) {
         this.plugin = plugin;
-        this.structureSaver = new StructureSaver(plugin); // Instantiate the saver
+        this.keys = keys;
+        this.structureSaver = new StructureSaver(plugin);
 
-        // Get WorldEdit plugin instance
         Plugin wep = Bukkit.getServer().getPluginManager().getPlugin("WorldEdit");
-        if (wep instanceof WorldEditPlugin) {
-            this.worldEdit = (WorldEditPlugin) wep;
+        if (wep instanceof WorldEditPlugin we) {
+            this.worldEdit = we;
         } else {
             this.worldEdit = null;
-            plugin.getLogger().severe("WorldEdit plugin not found or is not the correct type! /sotsavesegment will not work.");
-            // Disable the command or handle appropriately
+            plugin.getLogger().severe("WorldEdit not found — /sotsavesegment will not work.");
         }
     }
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if (!(sender instanceof Player)) {
-            // Use Adventure Component for console message
-            sender.sendMessage(Component.text("This command can only be run by a player.", NamedTextColor.RED));
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(Component.text("Players only.", NamedTextColor.RED));
             return true;
         }
         if (worldEdit == null) {
-             // Use Adventure Component for player message
-             sender.sendMessage(Component.text("WorldEdit is not available. Cannot save segment.", NamedTextColor.RED));
-             return true;
+            player.sendMessage(Component.text("WorldEdit is not available.", NamedTextColor.RED));
+            return true;
         }
-
-        Player player = (Player) sender;
-
-        // --- Argument Parsing (Basic Example) ---
-        if (args.length < 3) {
-            // Send usage message using Adventure Components
-            player.sendMessage(Component.text("Usage: /" + label + " <name> <type> <schematic_filename> [totalCoins]", NamedTextColor.RED));
-            player.sendMessage(Component.text("Example: /" + label + " my_room CORRIDOR my_room.schem 50", NamedTextColor.GRAY));
-            // TODO: List available SegmentTypes using Adventure
-            player.sendMessage(Component.text("Available types: ", NamedTextColor.GRAY)
-                .append(Component.text(String.join(", ", getSegmentTypeNames()), NamedTextColor.WHITE)));
+        if (args.length < 2) {
+            player.sendMessage(Component.text("Usage: /" + label + " <name> <type> [totalCoins]", NamedTextColor.RED));
+            player.sendMessage(Component.text("Types: " + getTypeNames(), NamedTextColor.GRAY));
             return true;
         }
 
         String segmentName = args[0];
-        String typeStr = args[1].toUpperCase();
-        String schematicFileName = args[2];
+        SegmentType segmentType;
+        try {
+            segmentType = SegmentType.valueOf(args[1].toUpperCase());
+        } catch (IllegalArgumentException e) {
+            player.sendMessage(Component.text("Invalid type: " + args[1] + ". Valid: " + getTypeNames(), NamedTextColor.RED));
+            return true;
+        }
+
         int totalCoins = 0;
-        if (args.length >= 4) {
+        if (args.length >= 3) {
             try {
-                totalCoins = Integer.parseInt(args[3]);
+                totalCoins = Integer.parseInt(args[2]);
             } catch (NumberFormatException e) {
-                // Use Adventure Component for error message
-                player.sendMessage(Component.text("Invalid number for totalCoins: " + args[3], NamedTextColor.RED));
+                player.sendMessage(Component.text("Invalid number for totalCoins: " + args[2], NamedTextColor.RED));
                 return true;
             }
         }
 
-        // Validate SegmentType
-        SegmentType segmentType;
-        try {
-            segmentType = SegmentType.valueOf(typeStr);
-        } catch (IllegalArgumentException e) {
-            // Use Adventure Component for error message
-            player.sendMessage(Component.text("Invalid segment type: " + args[1], NamedTextColor.RED));
-            player.sendMessage(Component.text("Valid types are: ", NamedTextColor.GRAY)
-                .append(Component.text(String.join(", ", getSegmentTypeNames()), NamedTextColor.WHITE)));
-            return true;
-        }
-
-        // Validate schematic filename format (basic)
-        if (!schematicFileName.toLowerCase().endsWith(".schem") && !schematicFileName.toLowerCase().endsWith(".schematic")) {
-             // Allow both common extensions
-             schematicFileName += ".schem"; // Append default if missing
-             // Use Adventure Component for info message
-             player.sendMessage(Component.text("Appending '.schem' to schematic filename.", NamedTextColor.YELLOW));
-        }
-
-        // --- Get WorldEdit Selection ---
+        // --- Get WorldEdit selection ---
         Region selection;
-        Location worldOrigin; // Absolute minimum point of the selection
+        Location worldOrigin;
         BlockVector3 size;
+        BlockVector3 selMin;
 
         try {
-            // Adapt player for WorldEdit session
-             com.sk89q.worldedit.entity.Player wePlayer = BukkitAdapter.adapt(player);
-             SessionManager sessionManager = WorldEdit.getInstance().getSessionManager();
-             LocalSession localSession = sessionManager.get(wePlayer);
+            com.sk89q.worldedit.entity.Player wePlayer = BukkitAdapter.adapt(player);
+            SessionManager sessionManager = WorldEdit.getInstance().getSessionManager();
+            LocalSession localSession = sessionManager.get(wePlayer);
+            selection = localSession.getSelection(wePlayer.getWorld());
 
-            // Get the selection from the player's session
-            selection = localSession.getSelection(wePlayer.getWorld()); // Pass world context
-            worldOrigin = BukkitAdapter.adapt(player.getWorld(), selection.getMinimumPoint()); // Convert WE min point to Bukkit Location
-
-            // Calculate size
             BlockVector3 min = selection.getMinimumPoint();
             BlockVector3 max = selection.getMaximumPoint();
-            size = max.subtract(min).add(1, 1, 1); // Size is max - min + 1
-
+            selMin = min;
+            worldOrigin = BukkitAdapter.adapt(player.getWorld(), min);
+            size = max.subtract(min).add(1, 1, 1);
         } catch (IncompleteRegionException e) {
-            // Use Adventure Component for error message
-            player.sendMessage(Component.text("Your WorldEdit selection is incomplete. Please select two points.", NamedTextColor.RED));
+            player.sendMessage(Component.text("WorldEdit selection is incomplete. Select two points first.", NamedTextColor.RED));
             return true;
         } catch (Exception e) {
-            plugin.getLogger().log(Level.SEVERE, "Error getting WorldEdit selection for " + player.getName(), e);
-            // Use Adventure Component for error message
-            player.sendMessage(Component.text("An error occurred while getting your WorldEdit selection.", NamedTextColor.RED));
+            plugin.getLogger().log(Level.SEVERE, "Error getting WorldEdit selection", e);
+            player.sendMessage(Component.text("Error reading WorldEdit selection.", NamedTextColor.RED));
             return true;
         }
 
-        // --- Create Segment Template (Basic - Missing complex data) ---
+        // --- Scan all build markers within the selection ---
+        BoundingBox bb = new BoundingBox(
+            selMin.x(), selMin.y(), selMin.z(),
+            selMin.x() + size.x(), selMin.y() + size.y(), selMin.z() + size.z()
+        );
+        Collection<Entity> nearby = player.getWorld().getNearbyEntities(bb);
+
+        List<Segment.RelativeEntryPoint> entryPoints   = new ArrayList<>();
+        List<BlockVector3>               coinSpawns     = new ArrayList<>();
+        List<BlockVector3>               itemSpawns     = new ArrayList<>();
+        List<BlockVector3>               sandSpawns     = new ArrayList<>();
+        List<BlockVector3>               sandSacrifices = new ArrayList<>();
+        List<BlockVector3>               mobSpawners    = new ArrayList<>();
+        List<SegmentBound>               gates          = new ArrayList<>();
+        SegmentBound                     vaultDoorBound = null;
+        BlockVector3                     leverOffset    = null;
+
+        for (Entity entity : nearby) {
+            if (!(entity instanceof BlockDisplay)) continue;
+            PersistentDataContainer pdc = entity.getPersistentDataContainer();
+            if (!pdc.has(keys.BUILD_MARKER_TAG, PersistentDataType.BYTE)) continue;
+
+            String type = pdc.get(keys.MARKER_TYPE, PersistentDataType.STRING);
+            if (type == null) continue;
+
+            // Skip purely visual entities — they carry no data
+            if (ToolListener.MT_BOUND_VISUAL.equals(type) || ToolListener.MT_BOUND_TEMP.equals(type)) continue;
+
+            BlockVector3 relPos = toRelative(entity.getLocation(), selMin);
+
+            switch (type) {
+                case ToolListener.MT_ENTRYPOINT -> {
+                    String dirStr = pdc.get(keys.DIRECTION, PersistentDataType.STRING);
+                    if (dirStr != null) {
+                        try {
+                            Direction dir = Direction.valueOf(dirStr);
+                            entryPoints.add(new Segment.RelativeEntryPoint(relPos, dir));
+                        } catch (IllegalArgumentException ex) {
+                            plugin.getLogger().warning("[SaveSegment] Unknown direction '" + dirStr + "' on entry point marker, skipping.");
+                        }
+                    }
+                }
+                case ToolListener.MT_COIN_SPAWN     -> coinSpawns.add(relPos);
+                case ToolListener.MT_ITEM_SPAWN     -> itemSpawns.add(relPos);
+                case ToolListener.MT_SAND_SPAWN     -> sandSpawns.add(relPos);
+                case ToolListener.MT_SAND_SACRIFICE -> sandSacrifices.add(relPos);
+                case ToolListener.MT_MOB_SPAWNER    -> mobSpawners.add(relPos);
+                case ToolListener.MT_LEVER          -> {
+                    if (leverOffset != null) {
+                        player.sendMessage(Component.text("Warning: multiple lever markers found — using the first.", NamedTextColor.YELLOW));
+                    } else {
+                        leverOffset = relPos;
+                    }
+                }
+                case ToolListener.MT_VAULT_DOOR -> {
+                    SegmentBound bound = readBound(pdc, selMin);
+                    if (bound != null) {
+                        if (vaultDoorBound != null) {
+                            player.sendMessage(Component.text("Warning: multiple vault door bounds found — using the first.", NamedTextColor.YELLOW));
+                        } else {
+                            vaultDoorBound = bound;
+                        }
+                    }
+                }
+                case ToolListener.MT_GATE -> {
+                    SegmentBound bound = readBound(pdc, selMin);
+                    if (bound != null) gates.add(bound);
+                }
+            }
+        }
+
+        // --- Validate gate ↔ lever constraint ---
+        if (!gates.isEmpty() && leverOffset == null) {
+            player.sendMessage(Component.text(
+                "Save failed: this segment has " + gates.size() + " gate(s) but no lever marker. Place a lever marker first.",
+                NamedTextColor.RED));
+            return true;
+        }
+        if (gates.isEmpty() && leverOffset != null) {
+            player.sendMessage(Component.text(
+                "Warning: lever marker found but no gates. Lever offset will be saved but may be unused.", NamedTextColor.YELLOW));
+        }
+
+        // --- Build summary feedback ---
+        player.sendMessage(Component.text("─── Segment Marker Summary ───", NamedTextColor.GOLD));
+        player.sendMessage(summary("Entry Points",    entryPoints.size()));
+        player.sendMessage(summary("Coin Spawns",     coinSpawns.size()));
+        player.sendMessage(summary("Item Spawns",     itemSpawns.size()));
+        player.sendMessage(summary("Sand Spawns",     sandSpawns.size()));
+        player.sendMessage(summary("Sand Sacrifices", sandSacrifices.size()));
+        player.sendMessage(summary("Mob Spawners",    mobSpawners.size()));
+        player.sendMessage(summary("Gates",           gates.size()));
+        player.sendMessage(Component.text("  Vault Door: ", NamedTextColor.GRAY)
+            .append(Component.text(vaultDoorBound != null ? "yes" : "none", vaultDoorBound != null ? NamedTextColor.GREEN : NamedTextColor.DARK_GRAY)));
+        player.sendMessage(Component.text("  Lever: ", NamedTextColor.GRAY)
+            .append(Component.text(leverOffset != null ? "yes" : "none", leverOffset != null ? NamedTextColor.GREEN : NamedTextColor.DARK_GRAY)));
+
+        // --- Construct Segment ---
+        String schematicFileName = segmentName.replaceAll("[^a-zA-Z0-9_.-]", "_") + ".schem";
+
         Segment segmentTemplate;
         try {
-            // TODO: Passing empty lists for entry/spawn points and null for vault/key info.
-            // A real implementation needs to get this data, likely via in-game marking or more args.
             segmentTemplate = new Segment(
-                    segmentName,
-                    segmentType,
-                    schematicFileName,
-                    size,
-                    new ArrayList<>(), // Empty Entry Points - NEEDS IMPLEMENTATION
-                    new ArrayList<>(), // Empty Sand Spawns - NEEDS IMPLEMENTATION
-                    new ArrayList<>(), // Empty Item Spawns - NEEDS IMPLEMENTATION
-                    new ArrayList<>(), // Empty Coin Spawns - NEEDS IMPLEMENTATION
-                    totalCoins,
-                    null, // No contained vault - NEEDS IMPLEMENTATION
-                    null, // No contained key - NEEDS IMPLEMENTATION
-                    null, // No vault offset - NEEDS IMPLEMENTATION
-                    null  // No key offset - NEEDS IMPLEMENTATION
+                segmentName,
+                segmentType,
+                schematicFileName,
+                size,
+                entryPoints,
+                sandSpawns,
+                itemSpawns,
+                coinSpawns,
+                totalCoins,
+                null,  // containedVault  — set manually in JSON if needed
+                null,  // containedVaultKey
+                null,  // vaultLocationOffset
+                null,  // keyLocationOffset
+                vaultDoorBound,
+                gates,
+                leverOffset,
+                sandSacrifices,
+                mobSpawners
             );
         } catch (Exception e) {
-             plugin.getLogger().log(Level.SEVERE, "Error creating Segment template object for " + segmentName, e);
-             // Use Adventure Component for error message
-             player.sendMessage(Component.text("An error occurred creating the segment template data.", NamedTextColor.RED));
-             return true;
+            plugin.getLogger().log(Level.SEVERE, "Error constructing Segment object for " + segmentName, e);
+            player.sendMessage(Component.text("Error building segment data. Check console.", NamedTextColor.RED));
+            return true;
         }
 
-
-        // --- Create PlacedSegment ---
-        // Depth is 0 as we are saving a base template outside generation context
+        // --- Save ---
         PlacedSegment placedSegment = new PlacedSegment(segmentTemplate, worldOrigin, 0);
-
-        // --- Call StructureSaver ---
-        // Use Adventure Component for status message
-        player.sendMessage(Component.text("Attempting to save segment '" + segmentName + "'...", NamedTextColor.YELLOW));
+        player.sendMessage(Component.text("Saving '" + segmentName + "'...", NamedTextColor.YELLOW));
         boolean success = structureSaver.saveStructure(placedSegment);
 
         if (success) {
-            // Use Adventure Components for success message
             player.sendMessage(Component.text("Segment '" + segmentName + "' saved successfully!", NamedTextColor.GREEN));
-            player.sendMessage(Component.text("Schematic: ", NamedTextColor.GREEN)
-                .append(Component.text(schematicFileName, NamedTextColor.WHITE)));
-            player.sendMessage(Component.text("Metadata: ", NamedTextColor.GREEN)
-                .append(Component.text(segmentName + ".json", NamedTextColor.WHITE)));
-            player.sendMessage(Component.text("Reload templates or restart server to use the new segment.", NamedTextColor.YELLOW));
-            // Consider adding automatic reloading if feasible
+            player.sendMessage(Component.text("  Schematic: " + schematicFileName, NamedTextColor.GREEN));
+            player.sendMessage(Component.text("  Metadata:  " + segmentName + ".json", NamedTextColor.GREEN));
+            player.sendMessage(Component.text("Reload templates to use the new segment.", NamedTextColor.YELLOW));
         } else {
-            // Use Adventure Component for failure message
-            player.sendMessage(Component.text("Failed to save segment '" + segmentName + "'. Check console for errors.", NamedTextColor.RED));
+            player.sendMessage(Component.text("Failed to save '" + segmentName + "'. Check console for errors.", NamedTextColor.RED));
         }
 
         return true;
     }
 
-    // Helper to get enum names (replace with your actual enum path)
-    private List<String> getSegmentTypeNames() {
-        // Using streams for a slightly more modern approach
-        return List.of(SegmentType.values()) // Get all enum values
-                   .stream()                 // Create a stream
-                   .map(Enum::name)          // Map each enum value to its name (String)
-                   .collect(Collectors.toList()); // Collect the names into a List
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Converts an entity's absolute block location to a relative offset from the selection minimum. */
+    private static BlockVector3 toRelative(Location loc, BlockVector3 selMin) {
+        return BlockVector3.at(
+            loc.getBlockX() - selMin.x(),
+            loc.getBlockY() - selMin.y(),
+            loc.getBlockZ() - selMin.z()
+        );
+    }
+
+    /** Reads the stored absolute BOUND_MIN/MAX from a data entity and converts to relative. */
+    private SegmentBound readBound(PersistentDataContainer pdc, BlockVector3 selMin) {
+        Integer minX = pdc.get(keys.BOUND_MIN_X, PersistentDataType.INTEGER);
+        Integer minY = pdc.get(keys.BOUND_MIN_Y, PersistentDataType.INTEGER);
+        Integer minZ = pdc.get(keys.BOUND_MIN_Z, PersistentDataType.INTEGER);
+        Integer maxX = pdc.get(keys.BOUND_MAX_X, PersistentDataType.INTEGER);
+        Integer maxY = pdc.get(keys.BOUND_MAX_Y, PersistentDataType.INTEGER);
+        Integer maxZ = pdc.get(keys.BOUND_MAX_Z, PersistentDataType.INTEGER);
+
+        if (minX == null || minY == null || minZ == null || maxX == null || maxY == null || maxZ == null) {
+            plugin.getLogger().warning("[SaveSegment] Bound data entity is missing coordinate PDC values, skipping.");
+            return null;
+        }
+
+        BlockVector3 relMin = BlockVector3.at(minX - selMin.x(), minY - selMin.y(), minZ - selMin.z());
+        BlockVector3 relMax = BlockVector3.at(maxX - selMin.x(), maxY - selMin.y(), maxZ - selMin.z());
+        return new SegmentBound(relMin, relMax);
+    }
+
+    private Component summary(String label, int count) {
+        NamedTextColor valueColor = count > 0 ? NamedTextColor.WHITE : NamedTextColor.DARK_GRAY;
+        return Component.text("  " + label + ": ", NamedTextColor.GRAY)
+            .append(Component.text(String.valueOf(count), valueColor));
+    }
+
+    private String getTypeNames() {
+        return java.util.Arrays.stream(SegmentType.values())
+            .map(Enum::name)
+            .collect(Collectors.joining(", "));
     }
 }

--- a/src/main/java/com/clarkson/sot/commands/SetBuilderModeCommand.java
+++ b/src/main/java/com/clarkson/sot/commands/SetBuilderModeCommand.java
@@ -1,0 +1,88 @@
+package com.clarkson.sot.commands;
+
+import com.clarkson.sot.main.SoT;
+import com.clarkson.sot.utils.BuilderSessionManager;
+import com.clarkson.sot.utils.PlayerBuilderSession;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * /sotmode <mode> — switches the segment builder tool's current placement mode.
+ */
+public class SetBuilderModeCommand implements CommandExecutor, TabCompleter {
+
+    private final SoT plugin;
+    private final BuilderSessionManager sessionManager;
+
+    public SetBuilderModeCommand(SoT plugin, BuilderSessionManager sessionManager) {
+        this.plugin = plugin;
+        this.sessionManager = sessionManager;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(Component.text("This command can only be run by a player.", NamedTextColor.RED));
+            return true;
+        }
+        if (!player.hasPermission("sot.builder.tool")) {
+            player.sendMessage(Component.text("You don't have permission to use this command.", NamedTextColor.RED));
+            return true;
+        }
+        if (args.length < 1) {
+            sendModeList(player);
+            return true;
+        }
+
+        BuilderMode mode;
+        try {
+            mode = BuilderMode.valueOf(args[0].toUpperCase());
+        } catch (IllegalArgumentException e) {
+            player.sendMessage(Component.text("Unknown mode: " + args[0], NamedTextColor.RED));
+            sendModeList(player);
+            return true;
+        }
+
+        PlayerBuilderSession session = sessionManager.getSession(player.getUniqueId());
+        session.setMode(mode);
+
+        player.sendMessage(Component.text("Builder mode: ", NamedTextColor.GRAY)
+            .append(Component.text(mode.getDisplayName(), NamedTextColor.YELLOW)));
+        player.sendActionBar(Component.text("[" + mode.getDisplayName() + "] " + mode.getHint(), NamedTextColor.YELLOW));
+        return true;
+    }
+
+    @Override
+    @Nullable
+    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (args.length == 1) {
+            String partial = args[0].toUpperCase();
+            return Arrays.stream(BuilderMode.values())
+                .map(Enum::name)
+                .filter(n -> n.startsWith(partial))
+                .collect(Collectors.toList());
+        }
+        return List.of();
+    }
+
+    private void sendModeList(Player player) {
+        player.sendMessage(Component.text("Available modes:", NamedTextColor.GRAY));
+        for (BuilderMode m : BuilderMode.values()) {
+            player.sendMessage(Component.text("  " + m.name(), NamedTextColor.YELLOW)
+                .append(Component.text(" — " + m.getHint(), NamedTextColor.DARK_GRAY)));
+        }
+    }
+}

--- a/src/main/java/com/clarkson/sot/dungeon/segment/Segment.java
+++ b/src/main/java/com/clarkson/sot/dungeon/segment/Segment.java
@@ -45,28 +45,40 @@ public class Segment {
     @Nullable private final BlockVector3 vaultLocationOffset; // Relative position of the vault marker block, if containedVault is not null
     @Nullable private final BlockVector3 keyLocationOffset;   // Relative position of the key spawn, if containedVaultKey is not null
 
+    // --- Structural Openings & Interactive Features ---
+    @Nullable private final SegmentBound vaultDoorBound;         // 2D bounds of the vault door opening (null if no vault door)
+    private final List<SegmentBound> gates;                      // 2D bounds of gate openings (may be empty)
+    @Nullable private final BlockVector3 leverOffset;            // Relative position of the gate lever (required when gates is non-empty)
+    private final List<BlockVector3> sandSacrificeLocations;     // Relative positions of sand sacrifice altars
+    private final List<BlockVector3> mobSpawnerLocations;        // Relative positions of mob spawner blocks
+
 
     /**
      * Constructor for creating a Segment template.
      * Values are typically loaded from JSON metadata.
      *
-     * @param name                Unique name of the segment template.
-     * @param type                General category/type of the segment (e.g., HUB, PUZZLE_ROOM).
-     * @param schematicFileName   Filename of the associated schematic (e.g., "my_segment.schem").
-     * @param size                Dimensions (width, height, length) of the segment.
-     * @param entryPoints         List of entry points with relative positions and directions.
-     * @param sandSpawnLocations  List of relative spawn locations for sand.
-     * @param itemSpawnLocations  List of relative spawn locations for items.
-     * @param coinSpawnLocations  List of relative spawn locations for coins.
-     * @param totalCoins          Approximate total base coin value in the segment.
-     * @param containedVault      The color of the vault entrance within this segment, or null.
-     * @param containedVaultKey   The color of the vault key found within this segment, or null.
-     * @param vaultLocationOffset Relative offset (from segment origin) of the vault marker block, if containedVault is not null.
-     * @param keyLocationOffset   Relative offset (from segment origin) of the key spawn location, if containedVaultKey is not null.
+     * @param name                   Unique name of the segment template.
+     * @param type                   General category/type of the segment (e.g., HUB, PUZZLE_ROOM).
+     * @param schematicFileName      Filename of the associated schematic (e.g., "my_segment.schem").
+     * @param size                   Dimensions (width, height, length) of the segment.
+     * @param entryPoints            List of entry points with relative positions and directions.
+     * @param sandSpawnLocations     List of relative spawn locations for sand.
+     * @param itemSpawnLocations     List of relative spawn locations for items.
+     * @param coinSpawnLocations     List of relative spawn locations for coins.
+     * @param totalCoins             Approximate total base coin value in the segment.
+     * @param containedVault         The color of the vault entrance within this segment, or null.
+     * @param containedVaultKey      The color of the vault key found within this segment, or null.
+     * @param vaultLocationOffset    Relative offset of the vault marker block, or null.
+     * @param keyLocationOffset      Relative offset of the key spawn location, or null.
+     * @param vaultDoorBound         2D bounds of the vault door opening, or null.
+     * @param gates                  List of 2D bounds for gate openings.
+     * @param leverOffset            Relative offset of the gate lever block (required when gates non-empty).
+     * @param sandSacrificeLocations List of relative positions of sand sacrifice altars.
+     * @param mobSpawnerLocations    List of relative positions of mob spawner blocks.
      */
     public Segment(
             @NotNull String name,
-            @Nullable SegmentType type, // Type is now crucial
+            @Nullable SegmentType type,
             @NotNull String schematicFileName,
             @NotNull BlockVector3 size,
             @NotNull List<RelativeEntryPoint> entryPoints,
@@ -77,7 +89,12 @@ public class Segment {
             @Nullable VaultColor containedVault,
             @Nullable VaultColor containedVaultKey,
             @Nullable BlockVector3 vaultLocationOffset,
-            @Nullable BlockVector3 keyLocationOffset
+            @Nullable BlockVector3 keyLocationOffset,
+            @Nullable SegmentBound vaultDoorBound,
+            @NotNull List<SegmentBound> gates,
+            @Nullable BlockVector3 leverOffset,
+            @NotNull List<BlockVector3> sandSacrificeLocations,
+            @NotNull List<BlockVector3> mobSpawnerLocations
     ) {
         // --- Basic Validation ---
         Objects.requireNonNull(name, "Segment name cannot be null");
@@ -101,7 +118,7 @@ public class Segment {
 
         // --- Assign Fields ---
         this.name = name;
-        this.type = type; // Assign the crucial type
+        this.type = type;
         this.schematicFileName = schematicFileName;
         this.size = size;
         this.entryPoints = new ArrayList<>(entryPoints);
@@ -109,14 +126,19 @@ public class Segment {
         this.itemSpawnLocations = new ArrayList<>(itemSpawnLocations);
         this.coinSpawnLocations = new ArrayList<>(coinSpawnLocations);
         this.totalCoins = totalCoins;
-        // Removed assignments for: coinMultiplier, isHub, isPuzzleRoom, isLavaParkour
 
-        // Assign Metadata Fields
+        // Vault / key metadata
         this.containedVault = containedVault;
         this.containedVaultKey = containedVaultKey;
-        // Assign Offset Fields
         this.vaultLocationOffset = vaultLocationOffset;
         this.keyLocationOffset = keyLocationOffset;
+
+        // Structural openings & interactive features
+        this.vaultDoorBound = vaultDoorBound;
+        this.gates = new ArrayList<>(gates);
+        this.leverOffset = leverOffset;
+        this.sandSacrificeLocations = new ArrayList<>(sandSacrificeLocations);
+        this.mobSpawnerLocations = new ArrayList<>(mobSpawnerLocations);
     }
 
     // --- Getters for Core Info ---
@@ -162,6 +184,13 @@ public class Segment {
     }
 
 
+    // --- Getters for Structural Openings & Interactive Features ---
+    @Nullable public SegmentBound getVaultDoorBound() { return vaultDoorBound; }
+    @NotNull  public List<SegmentBound> getGates() { return Collections.unmodifiableList(gates); }
+    @Nullable public BlockVector3 getLeverOffset() { return leverOffset; }
+    @NotNull  public List<BlockVector3> getSandSacrificeLocations() { return Collections.unmodifiableList(sandSacrificeLocations); }
+    @NotNull  public List<BlockVector3> getMobSpawnerLocations() { return Collections.unmodifiableList(mobSpawnerLocations); }
+
     // --- Template-related Logic ---
     public boolean hasEntryPointInDirection(@NotNull Direction dir) {
         Objects.requireNonNull(dir, "Direction cannot be null");
@@ -197,15 +226,19 @@ public class Segment {
 
     @Override
     public String toString() {
-        // Updated toString to remove deleted fields
         return "Segment{" +
                 "name='" + name + '\'' +
-                ", type=" + type + // Type is now primary descriptor
+                ", type=" + type +
                 ", schematic='" + schematicFileName + '\'' +
                 ", size=" + size +
                 ", entryPoints=" + entryPoints.size() +
                 ", vault=" + containedVault + (vaultLocationOffset != null ? "@" + vaultLocationOffset : "") +
                 ", key=" + containedVaultKey + (keyLocationOffset != null ? "@" + keyLocationOffset : "") +
+                ", vaultDoor=" + vaultDoorBound +
+                ", gates=" + gates.size() +
+                (leverOffset != null ? ", lever@" + leverOffset : "") +
+                ", sandSacrifice=" + sandSacrificeLocations.size() +
+                ", mobSpawners=" + mobSpawnerLocations.size() +
                 '}';
     }
 

--- a/src/main/java/com/clarkson/sot/dungeon/segment/SegmentBound.java
+++ b/src/main/java/com/clarkson/sot/dungeon/segment/SegmentBound.java
@@ -1,0 +1,30 @@
+package com.clarkson.sot.dungeon.segment;
+
+import com.sk89q.worldedit.math.BlockVector3;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a 2D bounded opening within a segment (vault door or gate).
+ * Corners are stored as relative offsets from the segment's minimum corner.
+ */
+public class SegmentBound {
+
+    private final BlockVector3 relativeMin;
+    private final BlockVector3 relativeMax;
+
+    public SegmentBound(@NotNull BlockVector3 relativeMin, @NotNull BlockVector3 relativeMax) {
+        this.relativeMin = relativeMin;
+        this.relativeMax = relativeMax;
+    }
+
+    @NotNull
+    public BlockVector3 getRelativeMin() { return relativeMin; }
+
+    @NotNull
+    public BlockVector3 getRelativeMax() { return relativeMax; }
+
+    @Override
+    public String toString() {
+        return "SegmentBound{min=" + relativeMin + ", max=" + relativeMax + "}";
+    }
+}

--- a/src/main/java/com/clarkson/sot/events/ToolListener.java
+++ b/src/main/java/com/clarkson/sot/events/ToolListener.java
@@ -1,22 +1,22 @@
 package com.clarkson.sot.events;
 
-// Use consistent key definitions - ideally move these to a shared Constants class
+import com.clarkson.sot.commands.BuilderMode;
+import com.clarkson.sot.dungeon.segment.Direction;
 import com.clarkson.sot.main.SoT;
-import com.clarkson.sot.dungeon.segment.Direction; // Import Direction
+import com.clarkson.sot.utils.BuilderSessionManager;
+import com.clarkson.sot.utils.PlayerBuilderSession;
+import com.clarkson.sot.utils.SegmentBuilderKeys;
 
-// Adventure API Imports
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.entity.Display;
-import org.bukkit.entity.Entity; // Import base Entity class
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.ItemDisplay;
+import org.bukkit.entity.BlockDisplay;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -28,367 +28,460 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.util.RayTraceResult; // Import for entity ray tracing
+import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Transformation;
 import org.joml.AxisAngle4f;
-import org.joml.Quaternionf; // Using Quaternion for potentially easier rotation
 import org.joml.Vector3f;
 
+import java.util.UUID;
+import java.util.function.Predicate;
 import java.util.logging.Level;
-import java.util.function.Predicate; // For ray trace filter
 
 /**
- * Listens for interactions with SoT tools.
- * Right-click places markers OR rotates existing entry point markers.
- * Left-click removes markers the player is looking at.
+ * Handles all interactions with the master Segment Builder tool.
+ *
+ * Right-click: place marker (mode-dependent).
+ * Left-click: remove marker in sight, or cancel in-progress bound selection.
+ *
+ * Marker visuals use BlockDisplay entities so they are clearly visible at distance.
+ * All markers are tagged with BUILD_MARKER_TAG and are never included in the saved schematic.
  */
 public class ToolListener implements Listener {
 
+    // --- Marker type string constants (package-private so SaveSegmentCommand can use them) ---
+    static final String MT_ENTRYPOINT     = "ENTRYPOINT";
+    static final String MT_COIN_SPAWN     = "COIN_SPAWN";
+    static final String MT_ITEM_SPAWN     = "ITEM_SPAWN";
+    static final String MT_SAND_SPAWN     = "SAND_SPAWN";
+    static final String MT_SAND_SACRIFICE = "SAND_SACRIFICE";
+    static final String MT_MOB_SPAWNER    = "MOB_SPAWNER";
+    static final String MT_LEVER          = "LEVER";
+    static final String MT_VAULT_DOOR     = "VAULT_DOOR";  // data entity
+    static final String MT_GATE           = "GATE";         // data entity
+    static final String MT_BOUND_VISUAL   = "BOUND_VISUAL"; // corner visual, no data
+    static final String MT_BOUND_TEMP     = "BOUND_TEMP";   // first-corner pending visual
+
+    private static final String TOOL_ID = "SEGMENT_BUILDER";
+
     private final SoT plugin;
+    private final BuilderSessionManager sessionManager;
+    final SegmentBuilderKeys keys; // package-private for SaveSegmentCommand
 
-    // --- Constants ---
-    private static final int COIN_STACK_SMALL_MODEL_ID = 1001;
-    private static final int COIN_STACK_MEDIUM_MODEL_ID = 1002;
-    private static final int COIN_STACK_LARGE_MODEL_ID = 1003;
-    private static final Material COIN_BASE_MATERIAL = Material.GOLD_NUGGET;
-    private static final Material ITEM_SPAWN_MARKER_ITEM_MATERIAL = Material.TORCH;
-    private static final Material ENTRY_POINT_MARKER_ITEM_MATERIAL = Material.ARROW; // Item to display for entry points
-
-    // --- PDC Keys (Define consistently) ---
-    private final NamespacedKey TOOL_TYPE_KEY;
-    private final NamespacedKey TOOL_VALUE_KEY; // Used by coin tool
-    private final NamespacedKey MARKER_TYPE_KEY; // Used for the marker entity (ItemDisplay or ArmorStand)
-    private final NamespacedKey DIRECTION_KEY; // Used for entry point marker entity
-    private final NamespacedKey VAULT_COLOR_KEY; // Used for vault/key marker entity
-    private final NamespacedKey BUILD_MARKER_TAG; // Tag identifying ANY build-phase marker entity
-
-    public ToolListener(SoT plugin) {
+    public ToolListener(SoT plugin, BuilderSessionManager sessionManager, SegmentBuilderKeys keys) {
         this.plugin = plugin;
-        // Initialize keys
-        TOOL_TYPE_KEY = new NamespacedKey(plugin, "sot_tool_type");
-        TOOL_VALUE_KEY = new NamespacedKey(plugin, "sot_tool_value");
-        MARKER_TYPE_KEY = new NamespacedKey(plugin, "sot_marker_type");
-        DIRECTION_KEY = new NamespacedKey(plugin, "sot_direction");
-        VAULT_COLOR_KEY = new NamespacedKey(plugin, "sot_vault_color");
-        BUILD_MARKER_TAG = new NamespacedKey(plugin, "sot_build_marker"); // Key for the general build marker tag
+        this.sessionManager = sessionManager;
+        this.keys = keys;
     }
+
+    // -------------------------------------------------------------------------
+    // Main event dispatcher
+    // -------------------------------------------------------------------------
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onPlayerInteract(PlayerInteractEvent event) {
-        if (event.getHand() != EquipmentSlot.HAND) return; // Only handle main hand
+        if (event.getHand() != EquipmentSlot.HAND) return;
 
         Player player = event.getPlayer();
-        ItemStack itemInHand = event.getItem();
+        ItemStack item = event.getItem();
+        if (item == null || item.getType() == Material.AIR) return;
 
-        if (itemInHand == null || itemInHand.getType() == Material.AIR) return;
-        ItemMeta meta = itemInHand.getItemMeta();
+        ItemMeta meta = item.getItemMeta();
         if (meta == null) return;
-        PersistentDataContainer pdc = meta.getPersistentDataContainer();
-        if (!pdc.has(TOOL_TYPE_KEY, PersistentDataType.STRING)) return; // Not one of our tools
+        if (!TOOL_ID.equals(meta.getPersistentDataContainer().get(keys.TOOL_TYPE, PersistentDataType.STRING))) return;
 
-        String toolType = pdc.get(TOOL_TYPE_KEY, PersistentDataType.STRING);
+        event.setCancelled(true);
 
-        // --- Handle Right-Click (Placement or Rotation) ---
-        if (event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
-            if ("COIN_PLACER".equals(toolType)) {
-                handleCoinPlacerTool(event, player, pdc);
-            } else if ("ITEM_SPAWN_PLACER".equals(toolType)) {
-                handleItemSpawnPlacerTool(event, player);
-            } else if ("ENTRY_POINT_PLACER".equals(toolType)) {
-                handleEntryPointPlacerTool(event, player); // Doesn't need tool PDC anymore
+        PlayerBuilderSession session = sessionManager.getSession(player.getUniqueId());
+        Action action = event.getAction();
+
+        if (action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK) {
+            handleRemoval(player, session);
+            return;
+        }
+
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) return;
+
+        BuilderMode mode = session.getMode();
+        switch (mode) {
+            case ENTRY_POINT -> handleEntryPoint(event, player, session);
+            case VAULT_DOOR  -> handleBoundCorner(event, player, session, false);
+            case GATE        -> handleBoundCorner(event, player, session, true);
+            default          -> handleSimpleMarker(event, player, mode);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Entry point handler
+    // -------------------------------------------------------------------------
+
+    private void handleEntryPoint(PlayerInteractEvent event, Player player, PlayerBuilderSession session) {
+        if (!player.hasPermission("sot.builder.place")) {
+            player.sendActionBar(Component.text("No permission.", NamedTextColor.RED));
+            return;
+        }
+
+        // Check if player is looking at an existing entry point marker → rotate it
+        Predicate<Entity> filter = e -> e instanceof BlockDisplay
+                && e.getPersistentDataContainer().has(keys.BUILD_MARKER_TAG, PersistentDataType.BYTE)
+                && MT_ENTRYPOINT.equals(e.getPersistentDataContainer().get(keys.MARKER_TYPE, PersistentDataType.STRING));
+
+        RayTraceResult result = player.getWorld().rayTraceEntities(
+                player.getEyeLocation(), player.getEyeLocation().getDirection(), 5.0, filter);
+
+        if (result != null && result.getHitEntity() instanceof BlockDisplay existing) {
+            rotateEntryPoint(player, existing);
+            return;
+        }
+
+        // Otherwise place a new marker
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK || event.getClickedBlock() == null) {
+            player.sendActionBar(Component.text("Right-click a wall face to place, or an existing marker to rotate.", NamedTextColor.YELLOW));
+            return;
+        }
+
+        Block clicked = event.getClickedBlock();
+        BlockFace face = event.getBlockFace();
+        Block target = clicked.getRelative(face);
+
+        if (!target.getType().isAir()) {
+            player.sendActionBar(Component.text("Cannot place here — air block required.", NamedTextColor.RED));
+            return;
+        }
+
+        Direction dir = Direction.fromBlockFace(face);
+        if (dir == null || dir == Direction.UP || dir == Direction.DOWN) {
+            dir = Direction.fromYaw(player.getLocation().getYaw());
+        }
+
+        final Direction finalDir = dir;
+        Location spawnLoc = target.getLocation();
+
+        try {
+            player.getWorld().spawn(spawnLoc, BlockDisplay.class, display -> {
+                display.setBlock(Bukkit.createBlockData(Material.LIME_STAINED_GLASS));
+                display.setGravity(false);
+                display.setInvulnerable(true);
+                display.setPersistent(true);
+                display.setGlowing(true);
+                display.setTransformation(fullBlockTransform());
+
+                PersistentDataContainer pdc = display.getPersistentDataContainer();
+                pdc.set(keys.BUILD_MARKER_TAG, PersistentDataType.BYTE, (byte) 1);
+                pdc.set(keys.MARKER_TYPE, PersistentDataType.STRING, MT_ENTRYPOINT);
+                pdc.set(keys.DIRECTION, PersistentDataType.STRING, finalDir.name());
+            });
+            player.sendActionBar(Component.text("Entry Point [" + finalDir.name() + "] placed — right-click to rotate.", NamedTextColor.GREEN));
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to spawn entry point marker", e);
+            player.sendMessage(Component.text("Error placing marker.", NamedTextColor.RED));
+        }
+    }
+
+    private void rotateEntryPoint(Player player, BlockDisplay display) {
+        PersistentDataContainer pdc = display.getPersistentDataContainer();
+        String currentStr = pdc.getOrDefault(keys.DIRECTION, PersistentDataType.STRING, Direction.NORTH.name());
+        Direction current;
+        try { current = Direction.valueOf(currentStr); } catch (IllegalArgumentException e) { current = Direction.NORTH; }
+
+        Direction next = switch (current) {
+            case NORTH -> Direction.EAST;
+            case EAST  -> Direction.SOUTH;
+            case SOUTH -> Direction.WEST;
+            default    -> Direction.NORTH;
+        };
+
+        pdc.set(keys.DIRECTION, PersistentDataType.STRING, next.name());
+        player.sendActionBar(Component.text("Entry Point rotated → " + next.name(), NamedTextColor.YELLOW));
+    }
+
+    // -------------------------------------------------------------------------
+    // Bound selection handler (VAULT_DOOR / GATE)
+    // -------------------------------------------------------------------------
+
+    private void handleBoundCorner(PlayerInteractEvent event, Player player, PlayerBuilderSession session, boolean isGate) {
+        if (!player.hasPermission("sot.builder.place")) {
+            player.sendActionBar(Component.text("No permission.", NamedTextColor.RED));
+            return;
+        }
+
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK || event.getClickedBlock() == null) {
+            String hint = session.hasPendingCorner()
+                    ? "First corner set — right-click a block face to set the second corner."
+                    : "Right-click a block face to set the first corner of the opening.";
+            player.sendActionBar(Component.text(hint, NamedTextColor.YELLOW));
+            return;
+        }
+
+        Block clicked = event.getClickedBlock();
+        Block target = clicked.getRelative(event.getBlockFace());
+
+        if (!target.getType().isAir()) {
+            player.sendActionBar(Component.text(
+                "Corner must be an open (air) block — click the face bordering the opening.", NamedTextColor.RED));
+            return;
+        }
+
+        Location cornerLoc = target.getLocation();
+        Material mat = isGate ? Material.LIGHT_GRAY_STAINED_GLASS : Material.PURPLE_STAINED_GLASS;
+        String label = isGate ? "Gate" : "Vault Door";
+
+        if (!session.hasPendingCorner()) {
+            // First corner: place temp entity and store in session
+            UUID tempId = spawnTempCornerMarker(player, cornerLoc, mat);
+            if (tempId != null) {
+                session.setPendingCorner(cornerLoc, tempId);
+                player.sendActionBar(Component.text(
+                    label + " — first corner set. Right-click the opposite corner.", NamedTextColor.YELLOW));
             }
-            // Add other right-click tool handlers here
-        }
-        // --- Handle Left-Click (Removal) ---
-        else if (event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK) {
-            // Check if the tool held is *any* of our placement tools
-            if ("COIN_PLACER".equals(toolType) || "ITEM_SPAWN_PLACER".equals(toolType) || "ENTRY_POINT_PLACER".equals(toolType)) {
-                 handleMarkerRemoval(event, player);
-            }
-        }
-    }
-
-    // --- Tool Handlers ---
-
-    private void handleCoinPlacerTool(PlayerInteractEvent event, Player player, PersistentDataContainer toolPdc) {
-        event.setCancelled(true);
-        if (!player.hasPermission("sot.admin.placedisplay")) { /* ... perm msg ... */ return; }
-        if (!toolPdc.has(TOOL_VALUE_KEY, PersistentDataType.INTEGER)) { /* ... missing value msg ... */ return; }
-        int baseValue = toolPdc.get(TOOL_VALUE_KEY, PersistentDataType.INTEGER);
-        spawnCoinDisplayVisual(player, baseValue, event.getClickedBlock(), event.getBlockFace());
-    }
-
-    private void handleItemSpawnPlacerTool(PlayerInteractEvent event, Player player) {
-        event.setCancelled(true);
-        if (!player.hasPermission("sot.admin.placeitemspawn")) { /* ... perm msg ... */ return; }
-        // Require clicking the top face of a block
-        if (event.getAction() != Action.RIGHT_CLICK_BLOCK || event.getClickedBlock() == null || event.getBlockFace() != BlockFace.UP) {
-             player.sendActionBar(Component.text("Right-click on the top face of a block to place marker.", NamedTextColor.YELLOW));
-             return;
-        }
-        placeItemSpawnMarker(player, event.getClickedBlock(), event.getBlockFace());
-    }
-
-    private void handleEntryPointPlacerTool(PlayerInteractEvent event, Player player) {
-        event.setCancelled(true); // Cancel event regardless of outcome below
-        if (!player.hasPermission("sot.admin.placeentrypoint")) {
-             player.sendMessage(Component.text("You don't have permission to use this tool.", NamedTextColor.RED));
-             return;
-        }
-
-        // 1. Check if player is looking at an existing Entry Point marker entity
-        double range = 5.0; // Range to check for existing markers
-        Predicate<Entity> filter = entity -> entity instanceof ItemDisplay // Check type
-                && entity.getPersistentDataContainer().has(BUILD_MARKER_TAG, PersistentDataType.BYTE) // Check general marker tag
-                && "ENTRYPOINT".equals(entity.getPersistentDataContainer().get(MARKER_TYPE_KEY, PersistentDataType.STRING)); // Check specific type
-
-        RayTraceResult result = player.getWorld().rayTraceEntities(player.getEyeLocation(), player.getEyeLocation().getDirection(), range, filter);
-
-        if (result != null && result.getHitEntity() != null && result.getHitEntity() instanceof ItemDisplay) {
-            // Player is looking at an existing entry point marker -> ROTATE IT
-            rotateEntryPointMarker(player, (ItemDisplay) result.getHitEntity());
-        }
-        // 2. If not looking at a marker, check if they right-clicked a block -> PLACE NEW
-        else if (event.getAction() == Action.RIGHT_CLICK_BLOCK && event.getClickedBlock() != null && event.getBlockFace() != null) {
-            // Place a new marker, default direction based on player facing away from block face
-            Direction defaultDirection = Direction.fromBlockFace(event.getBlockFace().getOppositeFace()); // Get direction pointing OUT from block
-             if(defaultDirection == Direction.UP || defaultDirection == Direction.DOWN) {
-                 // If clicked top/bottom, default to player's horizontal facing
-                 defaultDirection = Direction.fromYaw(player.getLocation().getYaw());
-             }
-            placeEntryPointMarker(player, event.getClickedBlock(), event.getBlockFace(), defaultDirection);
-        }
-        // 3. If right-clicked air and not looking at marker -> do nothing or give feedback
-        else if (event.getAction() == Action.RIGHT_CLICK_AIR) {
-             player.sendActionBar(Component.text("Right-click a block face to place, or an existing marker to rotate.", NamedTextColor.YELLOW));
-        }
-    }
-
-
-    /** Handles logic for removing markers (Left-Click) */
-    private void handleMarkerRemoval(PlayerInteractEvent event, Player player) {
-        event.setCancelled(true);
-        if (!player.hasPermission("sot.admin.removemarker")) {
-             player.sendActionBar(Component.text("You don't have permission to remove markers.", NamedTextColor.RED));
-             return;
-        }
-        double range = 6.0;
-        Predicate<Entity> filter = entity -> (entity instanceof ItemDisplay) // Only check ItemDisplays now if ArmorStands aren't used
-                   && entity.getPersistentDataContainer().has(BUILD_MARKER_TAG, PersistentDataType.BYTE);
-
-        RayTraceResult result = player.getWorld().rayTraceEntities(player.getEyeLocation(), player.getEyeLocation().getDirection(), range, filter);
-
-        if (result != null && result.getHitEntity() != null) {
-            Entity hitEntity = result.getHitEntity();
-            // No need to double-check tag if filter is reliable
-            String markerType = hitEntity.getPersistentDataContainer().getOrDefault(MARKER_TYPE_KEY, PersistentDataType.STRING, "Unknown");
-            hitEntity.remove();
-            player.sendActionBar(Component.text("Removed " + markerType + " marker.", NamedTextColor.YELLOW));
         } else {
-            player.sendActionBar(Component.text("No marker found in sight.", NamedTextColor.GRAY));
+            // Second corner: complete the bound
+            Location corner1 = session.getPendingCorner1();
+            UUID tempId = session.getPendingCornerEntityId();
+            if (tempId != null) {
+                Entity temp = Bukkit.getEntity(tempId);
+                if (temp != null) temp.remove();
+            }
+            session.clearPendingBound();
+            completeBound(player, corner1, cornerLoc, isGate ? MT_GATE : MT_VAULT_DOOR, mat, label);
         }
     }
 
+    private UUID spawnTempCornerMarker(Player player, Location loc, Material mat) {
+        UUID[] holder = {null};
+        try {
+            player.getWorld().spawn(loc, BlockDisplay.class, display -> {
+                display.setBlock(Bukkit.createBlockData(mat));
+                display.setGravity(false);
+                display.setInvulnerable(true);
+                display.setPersistent(true);
+                display.setGlowing(true);
+                // Slightly inset so it's visually distinct from permanent corners
+                display.setTransformation(new Transformation(
+                    new Vector3f(0.1f, 0.1f, 0.1f), new AxisAngle4f(0, 0, 0, 1),
+                    new Vector3f(0.8f, 0.8f, 0.8f), new AxisAngle4f(0, 0, 0, 1)
+                ));
+                PersistentDataContainer pdc = display.getPersistentDataContainer();
+                pdc.set(keys.BUILD_MARKER_TAG, PersistentDataType.BYTE, (byte) 1);
+                pdc.set(keys.MARKER_TYPE, PersistentDataType.STRING, MT_BOUND_TEMP);
+                holder[0] = display.getUniqueId();
+            });
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to spawn temp corner marker", e);
+        }
+        return holder[0];
+    }
 
-    // --- Spawning and Rotating Methods ---
+    private void completeBound(Player player, Location corner1, Location corner2,
+                               String markerType, Material mat, String label) {
+        int minX = Math.min(corner1.getBlockX(), corner2.getBlockX());
+        int minY = Math.min(corner1.getBlockY(), corner2.getBlockY());
+        int minZ = Math.min(corner1.getBlockZ(), corner2.getBlockZ());
+        int maxX = Math.max(corner1.getBlockX(), corner2.getBlockX());
+        int maxY = Math.max(corner1.getBlockY(), corner2.getBlockY());
+        int maxZ = Math.max(corner1.getBlockZ(), corner2.getBlockZ());
 
-    /** Spawns the visual ItemDisplay for a coin stack. */
-    private void spawnCoinDisplayVisual(Player player, int baseValue, Block clickedBlock, BlockFace clickedFace) {
-        int modelIdToUse;
-        if (baseValue >= 50) modelIdToUse = COIN_STACK_LARGE_MODEL_ID;
-        else if (baseValue >= 20) modelIdToUse = COIN_STACK_MEDIUM_MODEL_ID;
-        else modelIdToUse = COIN_STACK_SMALL_MODEL_ID;
+        String boundId = UUID.randomUUID().toString();
 
-        ItemStack displayStack = new ItemStack(COIN_BASE_MATERIAL);
-        ItemMeta meta = displayStack.getItemMeta();
-        if (meta != null) { meta.setCustomModelData(modelIdToUse); displayStack.setItemMeta(meta); }
-        else { player.sendMessage(Component.text("Error: Could not get ItemMeta for Coin Display.", NamedTextColor.RED)); return; }
+        // Two corner visuals
+        spawnBoundCornerVisual(player, new Location(player.getWorld(), minX, minY, minZ), mat, boundId);
+        spawnBoundCornerVisual(player, new Location(player.getWorld(), maxX, maxY, maxZ), mat, boundId);
 
-        Location spawnLocation = calculatePlacementLocation(player, clickedBlock, clickedFace, 0.1);
+        // Central data entity — stores the absolute min/max for SaveSegmentCommand to read
+        double cx = (minX + maxX + 1) / 2.0;
+        double cy = (minY + maxY + 1) / 2.0;
+        double cz = (minZ + maxZ + 1) / 2.0;
+        Location centerLoc = new Location(player.getWorld(), cx, cy, cz);
 
         try {
-            player.getWorld().spawn(spawnLocation, ItemDisplay.class, display -> {
-                display.setItemStack(displayStack);
-                display.setGravity(false); display.setInvulnerable(true); display.setBillboard(Display.Billboard.CENTER);
-                float scale = 1.5f;
-                Transformation transformation = new Transformation( new Vector3f(0f, 0f, 0f), new AxisAngle4f(0f, 0f, 0f, 1f), new Vector3f(scale, scale, scale), new AxisAngle4f(0f, 0f, 0f, 1f) );
-                display.setTransformation(transformation);
+            player.getWorld().spawn(centerLoc, BlockDisplay.class, display -> {
+                display.setBlock(Bukkit.createBlockData(mat));
+                display.setGravity(false);
+                display.setInvulnerable(true);
+                display.setPersistent(true);
+                display.setGlowing(true);
+                // Small cube to mark the data entity
+                display.setTransformation(new Transformation(
+                    new Vector3f(-0.15f, -0.15f, -0.15f), new AxisAngle4f(0, 0, 0, 1),
+                    new Vector3f(0.3f, 0.3f, 0.3f), new AxisAngle4f(0, 0, 0, 1)
+                ));
                 PersistentDataContainer pdc = display.getPersistentDataContainer();
-                pdc.set(BUILD_MARKER_TAG, PersistentDataType.BYTE, (byte)1);
-                pdc.set(MARKER_TYPE_KEY, PersistentDataType.STRING, "DISPLAY_COIN"); // Add type for removal message
+                pdc.set(keys.BUILD_MARKER_TAG, PersistentDataType.BYTE, (byte) 1);
+                pdc.set(keys.MARKER_TYPE, PersistentDataType.STRING, markerType);
+                pdc.set(keys.BOUND_ID, PersistentDataType.STRING, boundId);
+                pdc.set(keys.BOUND_MIN_X, PersistentDataType.INTEGER, minX);
+                pdc.set(keys.BOUND_MIN_Y, PersistentDataType.INTEGER, minY);
+                pdc.set(keys.BOUND_MIN_Z, PersistentDataType.INTEGER, minZ);
+                pdc.set(keys.BOUND_MAX_X, PersistentDataType.INTEGER, maxX);
+                pdc.set(keys.BOUND_MAX_Y, PersistentDataType.INTEGER, maxY);
+                pdc.set(keys.BOUND_MAX_Z, PersistentDataType.INTEGER, maxZ);
             });
-            player.sendActionBar(Component.text("Placed Coin Display (Value: " + baseValue + ")", NamedTextColor.GREEN));
         } catch (Exception e) {
-             plugin.getLogger().log(Level.SEVERE, "Failed to spawn Coin ItemDisplay via tool", e);
-             player.sendMessage(Component.text("An error occurred while spawning the coin display entity.", NamedTextColor.RED));
+            plugin.getLogger().log(Level.SEVERE, "Failed to spawn bound data entity", e);
+            player.sendMessage(Component.text("Error placing bound.", NamedTextColor.RED));
+            return;
+        }
+
+        int w = maxX - minX + 1;
+        int h = maxY - minY + 1;
+        player.sendActionBar(Component.text(
+            label + " bound placed. " + w + " wide × " + h + " tall.", NamedTextColor.GREEN));
+    }
+
+    private void spawnBoundCornerVisual(Player player, Location loc, Material mat, String boundId) {
+        try {
+            player.getWorld().spawn(loc, BlockDisplay.class, display -> {
+                display.setBlock(Bukkit.createBlockData(mat));
+                display.setGravity(false);
+                display.setInvulnerable(true);
+                display.setPersistent(true);
+                display.setGlowing(true);
+                display.setTransformation(new Transformation(
+                    new Vector3f(0f, 0f, 0f), new AxisAngle4f(0, 0, 0, 1),
+                    new Vector3f(0.5f, 0.5f, 0.5f), new AxisAngle4f(0, 0, 0, 1)
+                ));
+                PersistentDataContainer pdc = display.getPersistentDataContainer();
+                pdc.set(keys.BUILD_MARKER_TAG, PersistentDataType.BYTE, (byte) 1);
+                pdc.set(keys.MARKER_TYPE, PersistentDataType.STRING, MT_BOUND_VISUAL);
+                pdc.set(keys.BOUND_ID, PersistentDataType.STRING, boundId);
+            });
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to spawn bound corner visual", e);
         }
     }
 
-    /** Places an ItemDisplay showing a flat torch item, tagged as an item spawn marker. */
-    private void placeItemSpawnMarker(Player player, Block clickedBlock, BlockFace clickedFace) {
-         Block blockToPlaceOn = clickedBlock; // Clicked on top face, place marker above
-         Block targetBlock = blockToPlaceOn.getRelative(BlockFace.UP); // Target air block above
-         Location spawnLocation = targetBlock.getLocation().add(0.5, 0.0, 0.5); // Center of the block space, Y aligned with base
+    // -------------------------------------------------------------------------
+    // Simple single-point marker handler (all other modes)
+    // -------------------------------------------------------------------------
 
-         if (!targetBlock.getType().isAir() && targetBlock.getType() != Material.CAVE_AIR && targetBlock.getType() != Material.VOID_AIR) {
-              player.sendActionBar(Component.text("Cannot place marker here (space occupied).", NamedTextColor.RED));
-              return;
-         }
-
-         try {
-             ItemStack torchItem = new ItemStack(ITEM_SPAWN_MARKER_ITEM_MATERIAL);
-             player.getWorld().spawn(spawnLocation, ItemDisplay.class, display -> {
-                 display.setItemStack(torchItem);
-                 display.setGravity(false); display.setInvulnerable(true); display.setPersistent(true); display.setBillboard(Display.Billboard.FIXED);
-                 float scale = 0.7f;
-                 AxisAngle4f rotation = new AxisAngle4f((float) Math.toRadians(90), 1f, 0f, 0f); // Lay flat on X axis
-                 Vector3f translation = new Vector3f(0f, -0.4f, 0f); // Lower slightly
-                 Transformation transformation = new Transformation( translation, rotation, new Vector3f(scale, scale, scale), new AxisAngle4f(0f, 0f, 0f, 1f) );
-                 display.setTransformation(transformation);
-                 PersistentDataContainer pdc = display.getPersistentDataContainer();
-                 pdc.set(MARKER_TYPE_KEY, PersistentDataType.STRING, "SPAWN_ITEM");
-                 pdc.set(BUILD_MARKER_TAG, PersistentDataType.BYTE, (byte)1);
-             });
-              player.sendActionBar(Component.text("Placed Item Spawn Marker (Torch Item).", NamedTextColor.GREEN));
-         } catch (Exception e) {
-             plugin.getLogger().log(Level.SEVERE, "Failed to spawn marker ItemDisplay for item spawn", e);
-             player.sendMessage(Component.text("Error placing marker entity.", NamedTextColor.RED));
-         }
-    }
-
-    /**
-     * Places a new ItemDisplay showing an arrow pointing in the specified direction,
-     * tagged as an entry point marker.
-     * @param player Player using the tool.
-     * @param clickedBlock The block clicked.
-     * @param clickedFace The face of the block clicked.
-     * @param directionToPlace The initial direction the entry point should face.
-     */
-    private void placeEntryPointMarker(Player player, Block clickedBlock, BlockFace clickedFace, Direction directionToPlace) {
-        Block targetBlock = clickedBlock.getRelative(clickedFace);
-        Location spawnLocation = targetBlock.getLocation().add(0.5, 0.5, 0.5); // Center of the target block
-
-        if (!targetBlock.getType().isAir() && targetBlock.getType() != Material.CAVE_AIR && targetBlock.getType() != Material.VOID_AIR) {
-             player.sendActionBar(Component.text("Cannot place entry marker here (space occupied).", NamedTextColor.RED));
-             return;
+    private void handleSimpleMarker(PlayerInteractEvent event, Player player, BuilderMode mode) {
+        if (!player.hasPermission("sot.builder.place")) {
+            player.sendActionBar(Component.text("No permission.", NamedTextColor.RED));
+            return;
         }
+
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK || event.getClickedBlock() == null) {
+            player.sendActionBar(Component.text(mode.getHint(), NamedTextColor.YELLOW));
+            return;
+        }
+
+        Block clicked = event.getClickedBlock();
+        Block target = clicked.getRelative(event.getBlockFace());
+
+        if (!target.getType().isAir()) {
+            player.sendActionBar(Component.text("Cannot place here — air block required.", NamedTextColor.RED));
+            return;
+        }
+
+        Material mat;
+        String markerType;
+        String label;
+
+        switch (mode) {
+            case COIN_SPAWN     -> { mat = Material.GOLD_BLOCK;          markerType = MT_COIN_SPAWN;     label = "Coin Spawn"; }
+            case ITEM_SPAWN     -> { mat = Material.CYAN_CONCRETE;       markerType = MT_ITEM_SPAWN;     label = "Item Spawn"; }
+            case SAND_SPAWN     -> { mat = Material.SAND;                markerType = MT_SAND_SPAWN;     label = "Sand Spawn"; }
+            case SAND_SACRIFICE -> { mat = Material.ORANGE_CONCRETE;     markerType = MT_SAND_SACRIFICE; label = "Sand Sacrifice"; }
+            case MOB_SPAWNER    -> { mat = Material.BONE_BLOCK;          markerType = MT_MOB_SPAWNER;    label = "Mob Spawner"; }
+            case LEVER          -> { mat = Material.REDSTONE_BLOCK;      markerType = MT_LEVER;          label = "Lever"; }
+            default             -> { player.sendActionBar(Component.text("Unknown mode.", NamedTextColor.RED)); return; }
+        }
+
+        final String finalMarkerType = markerType;
+        final String finalLabel = label;
+        Location spawnLoc = target.getLocation();
 
         try {
-            ItemStack arrowItem = new ItemStack(ENTRY_POINT_MARKER_ITEM_MATERIAL);
-            AxisAngle4f rotation = calculateRotationForDirection(directionToPlace); // Use helper
-            float scale = 1.0f;
-            Vector3f translation = new Vector3f(0f, 0f, 0f);
-            Transformation transformation = new Transformation(translation, rotation, new Vector3f(scale, scale, scale), new AxisAngle4f());
-
-            player.getWorld().spawn(spawnLocation, ItemDisplay.class, display -> {
-                display.setItemStack(arrowItem);
-                display.setGravity(false); display.setInvulnerable(true); display.setPersistent(true); display.setBillboard(Display.Billboard.FIXED);
-                display.setTransformation(transformation); // Apply calculated rotation
-
+            player.getWorld().spawn(spawnLoc, BlockDisplay.class, display -> {
+                display.setBlock(Bukkit.createBlockData(mat));
+                display.setGravity(false);
+                display.setInvulnerable(true);
+                display.setPersistent(true);
+                display.setGlowing(true);
+                // Small cube sitting on the floor of the target block
+                display.setTransformation(new Transformation(
+                    new Vector3f(0.25f, 0f, 0.25f), new AxisAngle4f(0, 0, 0, 1),
+                    new Vector3f(0.5f, 0.5f, 0.5f), new AxisAngle4f(0, 0, 0, 1)
+                ));
                 PersistentDataContainer pdc = display.getPersistentDataContainer();
-                pdc.set(MARKER_TYPE_KEY, PersistentDataType.STRING, "ENTRYPOINT");
-                pdc.set(DIRECTION_KEY, PersistentDataType.STRING, directionToPlace.name()); // Store initial direction
-                pdc.set(BUILD_MARKER_TAG, PersistentDataType.BYTE, (byte)1);
+                pdc.set(keys.BUILD_MARKER_TAG, PersistentDataType.BYTE, (byte) 1);
+                pdc.set(keys.MARKER_TYPE, PersistentDataType.STRING, finalMarkerType);
             });
-
-            player.sendActionBar(Component.text("Placed Entry Point Marker (" + directionToPlace.name() + ").", NamedTextColor.GREEN));
-
+            player.sendActionBar(Component.text(finalLabel + " marker placed.", NamedTextColor.GREEN));
         } catch (Exception e) {
-            plugin.getLogger().log(Level.SEVERE, "Failed to spawn marker ItemDisplay for entry point", e);
-            player.sendMessage(Component.text("Error placing marker entity.", NamedTextColor.RED));
+            plugin.getLogger().log(Level.SEVERE, "Failed to spawn " + markerType + " marker", e);
+            player.sendMessage(Component.text("Error placing marker.", NamedTextColor.RED));
         }
     }
 
-     /**
-      * Rotates an existing entry point marker entity to the next cardinal direction.
-      * @param player The player triggering the rotation.
-      * @param display The ItemDisplay entity representing the entry point marker.
-      */
-     private void rotateEntryPointMarker(Player player, ItemDisplay display) {
-         PersistentDataContainer pdc = display.getPersistentDataContainer();
-         // Redundant check if filter works, but safe
-         if (!"ENTRYPOINT".equals(pdc.get(MARKER_TYPE_KEY, PersistentDataType.STRING))) return;
+    // -------------------------------------------------------------------------
+    // Removal handler
+    // -------------------------------------------------------------------------
 
-         String currentDirStr = pdc.get(DIRECTION_KEY, PersistentDataType.STRING);
-         Direction currentDirection;
-         try {
-             currentDirection = (currentDirStr != null) ? Direction.valueOf(currentDirStr) : Direction.NORTH;
-         } catch (IllegalArgumentException e) { currentDirection = Direction.NORTH; }
+    private void handleRemoval(Player player, PlayerBuilderSession session) {
+        if (!player.hasPermission("sot.builder.remove")) {
+            player.sendActionBar(Component.text("No permission to remove markers.", NamedTextColor.RED));
+            return;
+        }
 
-         // Cycle through cardinal directions: N -> E -> S -> W -> N
-         Direction nextDirection;
-         switch (currentDirection) {
-             case NORTH: nextDirection = Direction.EAST; break;
-             case EAST:  nextDirection = Direction.SOUTH; break;
-             case SOUTH: nextDirection = Direction.WEST; break;
-             case WEST:
-             default:    nextDirection = Direction.NORTH; break;
-         }
+        // If a bound is in progress, left-click cancels it
+        if (session.hasPendingCorner()) {
+            UUID tempId = session.getPendingCornerEntityId();
+            if (tempId != null) {
+                Entity temp = Bukkit.getEntity(tempId);
+                if (temp != null) temp.remove();
+            }
+            session.clearPendingBound();
+            player.sendActionBar(Component.text("Pending bound selection cancelled.", NamedTextColor.YELLOW));
+            return;
+        }
 
-         // Update PDC
-         pdc.set(DIRECTION_KEY, PersistentDataType.STRING, nextDirection.name());
+        Predicate<Entity> filter = e -> e instanceof BlockDisplay
+                && e.getPersistentDataContainer().has(keys.BUILD_MARKER_TAG, PersistentDataType.BYTE);
 
-         // Update Transformation
-         AxisAngle4f newRotation = calculateRotationForDirection(nextDirection);
-         
-         Transformation currentTransform = display.getTransformation();
-         // Create new transformation keeping scale/translation, only changing rotation
-         Quaternionf quaternionRotation = new Quaternionf(newRotation);
+        RayTraceResult result = player.getWorld().rayTraceEntities(
+                player.getEyeLocation(), player.getEyeLocation().getDirection(), 6.0, filter);
 
-        // Create the new Transformation object
-        Transformation newTransform = new Transformation(
-            currentTransform.getTranslation(),
-            quaternionRotation, // Use the converted Quaternionf
-            currentTransform.getScale(),
-            currentTransform.getRightRotation()
+        if (result == null || result.getHitEntity() == null) {
+            player.sendActionBar(Component.text("No marker in sight.", NamedTextColor.GRAY));
+            return;
+        }
+
+        Entity hit = result.getHitEntity();
+        PersistentDataContainer pdc = hit.getPersistentDataContainer();
+        String markerType = pdc.getOrDefault(keys.MARKER_TYPE, PersistentDataType.STRING, "Unknown");
+        String boundId = pdc.get(keys.BOUND_ID, PersistentDataType.STRING);
+
+        // If the removed entity is the temp first-corner, also clear the session
+        if (MT_BOUND_TEMP.equals(markerType)) {
+            session.clearPendingBound();
+        }
+
+        if (boundId != null) {
+            // Remove all entities belonging to this bound group
+            int count = 0;
+            for (Entity e : player.getWorld().getEntities()) {
+                if (e instanceof BlockDisplay
+                        && boundId.equals(e.getPersistentDataContainer().get(keys.BOUND_ID, PersistentDataType.STRING))) {
+                    e.remove();
+                    count++;
+                }
+            }
+            player.sendActionBar(Component.text("Removed bound (" + count + " entities).", NamedTextColor.YELLOW));
+        } else {
+            hit.remove();
+            player.sendActionBar(Component.text("Removed " + markerType + " marker.", NamedTextColor.YELLOW));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Transformation helpers
+    // -------------------------------------------------------------------------
+
+    /** A transformation that fills the full 1×1×1 block space starting at the entity origin. */
+    private static Transformation fullBlockTransform() {
+        return new Transformation(
+            new Vector3f(0f, 0f, 0f), new AxisAngle4f(0, 0, 0, 1),
+            new Vector3f(1f, 1f, 1f), new AxisAngle4f(0, 0, 0, 1)
         );
-
-        // Apply the new transformation
-        display.setTransformation(newTransform);
-         display.setTransformation(newTransform);
-
-         player.sendActionBar(Component.text("Rotated Entry Point Marker to " + nextDirection.name(), NamedTextColor.YELLOW));
-     }
-
-     /** Calculates the Y-axis rotation for an ItemDisplay arrow to face a direction. */
-     private AxisAngle4f calculateRotationForDirection(Direction direction) {
-          float yaw = 0f; // Default: South
-          switch (direction) {
-              case NORTH: yaw = 180f; break;
-              case EAST:  yaw = -90f; break;
-              case WEST:  yaw = 90f;  break;
-              case SOUTH: yaw = 0f;   break;
-              // UP/DOWN would need X/Z rotation, not handled here
-            default:
-                break;
-          }
-          // Rotation around Y axis
-          return new AxisAngle4f((float) Math.toRadians(yaw), 0f, 1f, 0f);
-     }
-
-
-     /** Helper to calculate placement location */
-     private Location calculatePlacementLocation(Player player, Block clickedBlock, BlockFace clickedFace, double yOffset) {
-        // ... (Implementation remains the same) ...
-         Location spawnLocation;
-         Location eyeLoc = player.getEyeLocation();
-         if (clickedBlock != null && clickedFace != null) {
-             Block potentialBlock = clickedBlock.getRelative(clickedFace);
-             if (!potentialBlock.getType().isSolid() || potentialBlock.isLiquid()) {
-                 spawnLocation = potentialBlock.getLocation().add(0.5, 0, 0.5);
-                 spawnLocation.setY(potentialBlock.getY() + yOffset);
-             } else {
-                 spawnLocation = eyeLoc.clone().add(player.getFacing().getDirection().multiply(1.5));
-                 spawnLocation.setY(Math.floor(spawnLocation.getY()) + yOffset);
-             }
-         } else {
-             spawnLocation = eyeLoc.clone().add(player.getFacing().getDirection().multiply(1.5));
-             spawnLocation.setY(Math.floor(spawnLocation.getY()) + yOffset);
-         }
-         spawnLocation.setPitch(0);
-         spawnLocation.setYaw(player.getLocation().getYaw());
-         return spawnLocation;
-     }
-
+    }
 }

--- a/src/main/java/com/clarkson/sot/main/SoT.java
+++ b/src/main/java/com/clarkson/sot/main/SoT.java
@@ -15,12 +15,16 @@ import com.clarkson.sot.dungeon.DungeonGenerator;
 import com.clarkson.sot.dungeon.VaultManager;
 import com.clarkson.sot.scoring.BankingManager;
 import com.clarkson.sot.scoring.ScoreManager;
+import com.clarkson.sot.utils.BuilderSessionManager;
 import com.clarkson.sot.utils.PlayerStateManager;
 import com.clarkson.sot.utils.SandManager;
+import com.clarkson.sot.utils.SegmentBuilderKeys;
 import com.clarkson.sot.utils.StructureLoader;
 import com.clarkson.sot.utils.TeamManager;
 // Import Commands
-import com.clarkson.sot.commands.*;
+import com.clarkson.sot.commands.GiveBuilderToolCommand;
+import com.clarkson.sot.commands.SaveSegmentCommand;
+import com.clarkson.sot.commands.SetBuilderModeCommand;
 // Import Listeners
 import com.clarkson.sot.events.ToolListener;
 // Import Entities if needed for static init
@@ -101,18 +105,19 @@ public class SoT extends JavaPlugin {
         CoinStack.initializeKeys(this);
 
 
-        // --- Register Commands ---
-        // Pass necessary managers to commands that need them
-        this.getCommand("sotplacecoindisplay").setExecutor(new PlaceCoinDisplayCommand(this));
-        this.getCommand("sotgetcointool").setExecutor(new GiveCoinToolCommand());
-        this.getCommand("sotgetitemtool").setExecutor(new GiveItemToolCommand(this));
-        this.getCommand("sotgetentrytool").setExecutor(new GiveEntryPointToolCommand(this));
-        // this.getCommand("sotsavesegment").setExecutor(new SaveSegmentCommand(this)); // Needs StructureSaver instance
+        // --- Shared builder infrastructure ---
+        SegmentBuilderKeys builderKeys = new SegmentBuilderKeys(this);
+        BuilderSessionManager sessionManager = new BuilderSessionManager();
 
+        // --- Register Commands ---
+        ToolListener toolListener = new ToolListener(this, sessionManager, builderKeys);
+        this.getCommand("sotbuilder").setExecutor(new GiveBuilderToolCommand(this, builderKeys));
+        this.getCommand("sotmode").setExecutor(new SetBuilderModeCommand(this, sessionManager));
+        this.getCommand("sotsavesegment").setExecutor(new SaveSegmentCommand(this, builderKeys));
 
         // --- Register Listeners ---
-        getServer().getPluginManager().registerEvents(new ToolListener(this), this);
-        getServer().getPluginManager().registerEvents(vaultManager, this); // VaultManager handles vault interactions
+        getServer().getPluginManager().registerEvents(toolListener, this);
+        getServer().getPluginManager().registerEvents(vaultManager, this);
 
 
         getLogger().info("Sands of Time Enabled Successfully.");

--- a/src/main/java/com/clarkson/sot/utils/BuilderSessionManager.java
+++ b/src/main/java/com/clarkson/sot/utils/BuilderSessionManager.java
@@ -1,0 +1,22 @@
+package com.clarkson.sot.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Holds per-player builder sessions. Shared between ToolListener and SetBuilderModeCommand.
+ */
+public class BuilderSessionManager {
+
+    private final Map<UUID, PlayerBuilderSession> sessions = new HashMap<>();
+
+    /** Gets or creates the session for a player. */
+    public PlayerBuilderSession getSession(UUID playerId) {
+        return sessions.computeIfAbsent(playerId, id -> new PlayerBuilderSession());
+    }
+
+    public void clearSession(UUID playerId) {
+        sessions.remove(playerId);
+    }
+}

--- a/src/main/java/com/clarkson/sot/utils/PlayerBuilderSession.java
+++ b/src/main/java/com/clarkson/sot/utils/PlayerBuilderSession.java
@@ -1,0 +1,43 @@
+package com.clarkson.sot.utils;
+
+import com.clarkson.sot.commands.BuilderMode;
+import org.bukkit.Location;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Tracks per-player state for the segment builder tool.
+ */
+public class PlayerBuilderSession {
+
+    private BuilderMode mode = BuilderMode.ENTRY_POINT;
+
+    // In-progress bound selection state (VAULT_DOOR / GATE modes)
+    @Nullable private Location pendingCorner1;
+    @Nullable private UUID pendingCornerEntityId;
+
+    public BuilderMode getMode() { return mode; }
+
+    /** Switches mode and clears any in-progress bound selection. */
+    public void setMode(BuilderMode mode) {
+        this.mode = mode;
+        clearPendingBound();
+    }
+
+    public boolean hasPendingCorner() { return pendingCorner1 != null; }
+
+    @Nullable public Location getPendingCorner1() { return pendingCorner1; }
+
+    @Nullable public UUID getPendingCornerEntityId() { return pendingCornerEntityId; }
+
+    public void setPendingCorner(Location corner, UUID entityId) {
+        this.pendingCorner1 = corner;
+        this.pendingCornerEntityId = entityId;
+    }
+
+    public void clearPendingBound() {
+        this.pendingCorner1 = null;
+        this.pendingCornerEntityId = null;
+    }
+}

--- a/src/main/java/com/clarkson/sot/utils/SegmentBuilderKeys.java
+++ b/src/main/java/com/clarkson/sot/utils/SegmentBuilderKeys.java
@@ -1,0 +1,54 @@
+package com.clarkson.sot.utils;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Centralised PDC key definitions for the segment builder tool.
+ * Shared between ToolListener and SaveSegmentCommand so key names stay in sync.
+ */
+public class SegmentBuilderKeys {
+
+    /** Identifies the master builder tool. Value: "SEGMENT_BUILDER". */
+    public final NamespacedKey TOOL_TYPE;
+
+    /** Identifies the type of a placed marker entity. */
+    public final NamespacedKey MARKER_TYPE;
+
+    /** Direction stored on ENTRYPOINT markers. */
+    public final NamespacedKey DIRECTION;
+
+    /** Vault colour stored on vault-related entities (currently unused on bounds, reserved). */
+    public final NamespacedKey VAULT_COLOR;
+
+    /** Tag present (as byte 1) on every build-phase marker entity. */
+    public final NamespacedKey BUILD_MARKER_TAG;
+
+    /** UUID string shared by all entities belonging to the same bound group. */
+    public final NamespacedKey BOUND_ID;
+
+    /** Absolute world coordinates of the bound minimum corner (stored on data entity). */
+    public final NamespacedKey BOUND_MIN_X;
+    public final NamespacedKey BOUND_MIN_Y;
+    public final NamespacedKey BOUND_MIN_Z;
+
+    /** Absolute world coordinates of the bound maximum corner (stored on data entity). */
+    public final NamespacedKey BOUND_MAX_X;
+    public final NamespacedKey BOUND_MAX_Y;
+    public final NamespacedKey BOUND_MAX_Z;
+
+    public SegmentBuilderKeys(Plugin plugin) {
+        TOOL_TYPE       = new NamespacedKey(plugin, "sot_tool_type");
+        MARKER_TYPE     = new NamespacedKey(plugin, "sot_marker_type");
+        DIRECTION       = new NamespacedKey(plugin, "sot_direction");
+        VAULT_COLOR     = new NamespacedKey(plugin, "sot_vault_color");
+        BUILD_MARKER_TAG = new NamespacedKey(plugin, "sot_build_marker");
+        BOUND_ID        = new NamespacedKey(plugin, "sot_bound_id");
+        BOUND_MIN_X     = new NamespacedKey(plugin, "sot_bound_min_x");
+        BOUND_MIN_Y     = new NamespacedKey(plugin, "sot_bound_min_y");
+        BOUND_MIN_Z     = new NamespacedKey(plugin, "sot_bound_min_z");
+        BOUND_MAX_X     = new NamespacedKey(plugin, "sot_bound_max_x");
+        BOUND_MAX_Y     = new NamespacedKey(plugin, "sot_bound_max_y");
+        BOUND_MAX_Z     = new NamespacedKey(plugin, "sot_bound_max_z");
+    }
+}

--- a/src/main/java/com/clarkson/sot/utils/StructureLoader.java
+++ b/src/main/java/com/clarkson/sot/utils/StructureLoader.java
@@ -1,10 +1,11 @@
 package com.clarkson.sot.utils;
 
 // Local project imports
-import com.clarkson.sot.dungeon.segment.*; // Import SegmentType
-import com.clarkson.sot.dungeon.VaultColor; // Import VaultColor
+import com.clarkson.sot.dungeon.segment.*;
+import com.clarkson.sot.dungeon.VaultColor;
 import com.clarkson.sot.dungeon.segment.Segment;
 import com.clarkson.sot.dungeon.segment.Segment.RelativeEntryPoint;
+import com.clarkson.sot.dungeon.segment.SegmentBound;
 
 // WorldEdit imports
 import com.sk89q.worldedit.math.BlockVector3;
@@ -163,24 +164,41 @@ public class StructureLoader {
                  keyLocationOffset = deserializeBlockVector3(json.getAsJsonObject("keyLocationOffset"), "keyLocationOffset", name, sourceFileName);
             }
 
+            // --- Deserialize structural openings & interactive features ---
+            SegmentBound vaultDoorBound = null;
+            if (json.has("vaultDoorBound") && json.get("vaultDoorBound").isJsonObject()) {
+                vaultDoorBound = deserializeSegmentBound(json.getAsJsonObject("vaultDoorBound"), "vaultDoorBound", name, sourceFileName);
+            }
+            List<SegmentBound> gates = deserializeSegmentBoundList(json.getAsJsonArray("gates"), "gates", name, sourceFileName);
+
+            BlockVector3 leverOffset = null;
+            if (json.has("leverOffset") && json.get("leverOffset").isJsonObject()) {
+                leverOffset = deserializeBlockVector3(json.getAsJsonObject("leverOffset"), "leverOffset", name, sourceFileName);
+            }
+
+            List<BlockVector3> sandSacrifice = deserializeBlockVectorList(json.getAsJsonArray("sandSacrificeLocations"), "sandSacrificeLocations", name, sourceFileName);
+            List<BlockVector3> mobSpawners   = deserializeBlockVectorList(json.getAsJsonArray("mobSpawnerLocations"), "mobSpawnerLocations", name, sourceFileName);
+
             // --- Construct the Segment Template Object ---
-            // Ensure this call matches the LATEST Segment constructor signature EXACTLY
             return new Segment(
                     name,
-                    type, // Pass the parsed SegmentType
+                    type,
                     schematicFileName,
                     size,
-                    // Provide empty lists if deserialization returned null (though helpers return empty lists now)
                     entryPoints != null ? entryPoints : new ArrayList<>(),
-                    sandSpawns != null ? sandSpawns : new ArrayList<>(),
-                    itemSpawns != null ? itemSpawns : new ArrayList<>(),
-                    coinSpawns != null ? coinSpawns : new ArrayList<>(),
-                    totalCoins != null ? totalCoins : 0, // Default totalCoins to 0 if missing/invalid
-                    // Removed arguments for: coinMultiplier, isHub, isPuzzleRoom, isLavaParkour
-                    containedVault,      // Can be null
-                    containedVaultKey,   // Can be null
-                    vaultLocationOffset, // Can be null
-                    keyLocationOffset    // Can be null
+                    sandSpawns  != null ? sandSpawns  : new ArrayList<>(),
+                    itemSpawns  != null ? itemSpawns  : new ArrayList<>(),
+                    coinSpawns  != null ? coinSpawns  : new ArrayList<>(),
+                    totalCoins  != null ? totalCoins  : 0,
+                    containedVault,
+                    containedVaultKey,
+                    vaultLocationOffset,
+                    keyLocationOffset,
+                    vaultDoorBound,
+                    gates,
+                    leverOffset,
+                    sandSacrifice,
+                    mobSpawners
             );
 
         } catch (JsonParseException | IllegalStateException | ClassCastException | NullPointerException e) {
@@ -311,6 +329,36 @@ public class StructureLoader {
             } // Error logged in deserializeBlockVector3 if null
         }
         return vectors;
+    }
+
+    /**
+     * Deserializes a JSON object representing a SegmentBound (min + max BlockVector3).
+     * Expected format: {"min": {"x":0,"y":0,"z":0}, "max": {"x":5,"y":3,"z":0}}
+     */
+    @Nullable
+    private SegmentBound deserializeSegmentBound(@Nullable JsonObject boundJson, String context, String segmentName, String sourceFileName) {
+        if (boundJson == null) return null;
+        BlockVector3 min = deserializeBlockVector3(boundJson.get("min"), context + ".min", segmentName, sourceFileName);
+        BlockVector3 max = deserializeBlockVector3(boundJson.get("max"), context + ".max", segmentName, sourceFileName);
+        if (min == null || max == null) {
+            plugin.getLogger().warning("[StructureLoader] Invalid SegmentBound (missing min or max) for '" + context + "' in template '" + segmentName + "' from " + sourceFileName);
+            return null;
+        }
+        return new SegmentBound(min, max);
+    }
+
+    private List<SegmentBound> deserializeSegmentBoundList(@Nullable JsonElement arrayElement, String listName, String segmentName, String sourceFileName) {
+        List<SegmentBound> bounds = new ArrayList<>();
+        if (arrayElement == null || !arrayElement.isJsonArray()) return bounds;
+        JsonArray arr = arrayElement.getAsJsonArray();
+        for (int i = 0; i < arr.size(); i++) {
+            JsonElement el = arr.get(i);
+            if (el != null && el.isJsonObject()) {
+                SegmentBound bound = deserializeSegmentBound(el.getAsJsonObject(), listName + "[" + i + "]", segmentName, sourceFileName);
+                if (bound != null) bounds.add(bound);
+            }
+        }
+        return bounds;
     }
 
     /**

--- a/src/main/java/com/clarkson/sot/utils/StructureSaver.java
+++ b/src/main/java/com/clarkson/sot/utils/StructureSaver.java
@@ -1,11 +1,12 @@
 package com.clarkson.sot.utils;
 
 // Local project imports
-import com.clarkson.sot.dungeon.segment.*; // Import SegmentType if needed by Segment
-import com.clarkson.sot.dungeon.VaultColor; // Import VaultColor if needed by Segment
+import com.clarkson.sot.dungeon.segment.*;
+import com.clarkson.sot.dungeon.VaultColor;
 import com.clarkson.sot.dungeon.segment.PlacedSegment;
 import com.clarkson.sot.dungeon.segment.Segment;
 import com.clarkson.sot.dungeon.segment.Segment.RelativeEntryPoint;
+import com.clarkson.sot.dungeon.segment.SegmentBound;
 
 // WorldEdit imports
 import com.sk89q.worldedit.EditSession;
@@ -24,7 +25,8 @@ import com.sk89q.worldedit.world.World; // WorldEdit World
 // Bukkit imports
 import org.bukkit.Location;
 import org.bukkit.plugin.Plugin;
-import org.jetbrains.annotations.Nullable; // For nullable checks
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 // Gson imports
 import com.google.gson.*;
@@ -343,6 +345,19 @@ public class StructureSaver {
                 json.add("keyLocationOffset", serializeBlockVector3(keyOffset));
             }
 
+            // --- Serialize structural openings & interactive features ---
+            SegmentBound vaultDoorBound = segmentTemplate.getVaultDoorBound();
+            if (vaultDoorBound != null) {
+                json.add("vaultDoorBound", serializeSegmentBound(vaultDoorBound));
+            }
+            json.add("gates", serializeSegmentBoundList(segmentTemplate.getGates(), segmentName));
+            BlockVector3 leverOffset = segmentTemplate.getLeverOffset();
+            if (leverOffset != null) {
+                json.add("leverOffset", serializeBlockVector3(leverOffset));
+            }
+            json.add("sandSacrificeLocations", serializeBlockVectorList(segmentTemplate.getSandSacrificeLocations(), "sandSacrificeLocations", segmentName));
+            json.add("mobSpawnerLocations", serializeBlockVectorList(segmentTemplate.getMobSpawnerLocations(), "mobSpawnerLocations", segmentName));
+
             return json;
 
         } catch (Exception e) {
@@ -392,6 +407,27 @@ public class StructureSaver {
             }
         }
         return jsonArray;
+    }
+
+    private JsonObject serializeSegmentBound(@NotNull SegmentBound bound) {
+        JsonObject obj = new JsonObject();
+        obj.add("min", serializeBlockVector3(bound.getRelativeMin()));
+        obj.add("max", serializeBlockVector3(bound.getRelativeMax()));
+        return obj;
+    }
+
+    private JsonArray serializeSegmentBoundList(@Nullable List<SegmentBound> bounds, String segmentName) {
+        JsonArray arr = new JsonArray();
+        if (bounds != null) {
+            for (SegmentBound b : bounds) {
+                if (b != null) {
+                    arr.add(serializeSegmentBound(b));
+                } else {
+                    plugin.getLogger().warning("[StructureSaver] Skipping null SegmentBound in list for: " + segmentName);
+                }
+            }
+        }
+        return arr;
     }
 
     // sanitizeFileName remains the same

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,70 +1,48 @@
 name: SoT
-version: '${project.version}' # Uses version from pom.xml
+version: '${project.version}'
 main: com.clarkson.sot.main.SoT
-api-version: '1.21' # <-- Updated to match target server/Java version
-depend: [WorldEdit] # Declare WorldEdit dependency
-loadbefore: [] # Optional: Add plugins that should load AFTER this one
-authors: [ZacClarkson] # Use list format for authors
+api-version: '1.21'
+depend: [WorldEdit]
+authors: [ZacClarkson]
 description: A minecraft game based on MCC
 
 commands:
-  # --- Builder Tool Commands ---
-  sotplacecoindisplay: # <-- Added definition
-    description: Spawns a visual coin stack display for segment building.
-    usage: /<command> <value>
-    permission: sot.admin.placedisplay
-  sotgetcointool:
-    description: Gives the player a tool to place Coin Displays.
-    usage: /<command> <value>
-    permission: sot.admin.givetool
-  sotgetitemtool: # <-- Added definition
-    description: Gives the player a tool to place Item Spawn markers.
+  # --- Segment Builder ---
+  sotbuilder:
+    description: Gives the master segment builder tool.
     usage: /<command>
-    permission: sot.admin.givetool # Reusing permission
-  sotgetentrytool: # <-- Added definition
-    description: Gives the player a tool to place Entry Point markers.
-    usage: /<command>
-    permission: sot.admin.givetool # Reusing permission
+    permission: sot.builder.tool
+  sotmode:
+    description: Switches the segment builder tool mode.
+    usage: /<command> <mode>
+    permission: sot.builder.tool
   sotsavesegment:
-    description: Saves the selected WorldEdit region as a new SoT segment template.
-    usage: /<command> <name> <type> <schematic_filename> [totalCoins]
+    description: Saves the WorldEdit selection as a new SoT segment template.
+    usage: /<command> <name> <type> [totalCoins]
     permission: sot.admin.savesegment
 
-  # --- Game Control Commands (Examples - Implement these) ---
+  # --- Game Control (implement as needed) ---
   # sot:
-    # description: Main command for Sands of Time game control.
-    # usage: /<command> <setup|start|end|set> ...
-    # permission: sot.admin.control
-    # aliases: [sandsoftime] # Optional aliases
-  # team:
-    # description: Command for team assignments.
-    # usage: /<command> assign <player> <TeamID>
-    # permission: sot.admin.team
+  #   description: Main game control command.
+  #   usage: /<command> <setup|start|end|set> ...
+  #   permission: sot.admin.control
 
 permissions:
-  sot.admin.givetool:
-    description: Allows getting the SoT builder tools (coin, item, entry point). # <-- Updated description
+  sot.builder.tool:
+    description: Allows getting and using the segment builder tool (place, rotate, remove markers, switch modes).
     default: op
-  sot.admin.placedisplay:
-    description: Allows placing visual coin displays for building using the tool.
+  sot.builder.place:
+    description: Allows placing segment markers with the builder tool.
     default: op
-  sot.admin.placeitemspawn:
-    description: Allows placing item spawn markers for building using the tool.
-    default: op
-  sot.admin.placeentrypoint: # <-- Added definition
-    description: Allows placing entry point markers for building using the tool.
-    default: op
-  sot.admin.removemarker:
-    description: Allows removing SoT builder markers with left-click using a tool.
+  sot.builder.remove:
+    description: Allows removing segment markers with the builder tool.
     default: op
   sot.admin.savesegment:
-    description: Allows saving new SoT segments.
+    description: Allows saving new SoT segment templates.
     default: op
-  sot.admin.control: # Example permission for game control
-    description: Allows controlling the SoT game state (setup, start, end, set).
+  sot.admin.control:
+    description: Allows controlling the SoT game state.
     default: op
-  sot.admin.team: # Example permission for team command
+  sot.admin.team:
     description: Allows managing SoT team assignments.
     default: op
-
-# ... potentially other plugin.yml sections like loadbefore/softdepend ...


### PR DESCRIPTION
## Summary

- Replaces three separate tool-give commands with a single **master BLAZE_ROD builder tool** (`/sotbuilder`) and a mode-switcher (`/sotmode <mode>`)
- All 9 placement modes use glowing `BlockDisplay` entities with distinct colour-coded materials so markers are clearly visible at build distance
- Two-click bound selection for vault doors and gates — first corner stored in per-player session, second corner completes the bound atomically; all bound entities share a `BOUND_ID` PDC key for atomic removal
- `/sotsavesegment <name> <type> [totalCoins]` scans `BUILD_MARKER_TAG` entities inside the WorldEdit selection, converts absolute positions to relative offsets, prints a marker summary, validates gate↔lever pairing, and saves metadata + schematic
- `Segment` data model extended with `vaultDoorBound`, `gates`, `leverOffset`, `sandSacrificeLocations`, `mobSpawnerLocations`; `StructureSaver`/`StructureLoader` updated to serialise/deserialise these fields
- Shared `SegmentBuilderKeys` ensures `ToolListener` and `SaveSegmentCommand` always use identical PDC key names
- `plugin.yml` consolidated to 3 commands and 3 permissions; old per-type tool commands removed

## Test plan

- [ ] `/sotbuilder` gives the BLAZE_ROD tool with correct PDC tag
- [ ] `/sotmode <mode>` switches mode and shows action-bar hint; tab-complete lists all modes
- [ ] Right-click places correct `BlockDisplay` marker for each mode with `BUILD_MARKER_TAG` and correct `MARKER_TYPE`
- [ ] Entry point markers rotate NORTH→EAST→SOUTH→WEST on repeated right-click
- [ ] Vault door / gate: first right-click places glowing temp corner; second completes bound (2 corner visuals + 1 data entity sharing `BOUND_ID`)
- [ ] Left-click with pending corner cancels selection and removes temp entity
- [ ] Left-click on bound entity removes all entities with the same `BOUND_ID`
- [ ] `/sotsavesegment` saves JSON with correct marker counts
- [ ] Save fails with clear error when gates exist but no lever marker
- [ ] Saved JSON round-trips correctly through `StructureLoader`

https://claude.ai/code/session_01AVF2BPSeGJVAGv2fcZuLkG