### PR TITLE
Segment builder tool: master tool, all marker types, full Segment serialization

### DIFF
--- a/src/main/java/com/clarkson/sot/commands/GiveBuilderToolCommand.java
+++ b/src/main/java/com/clarkson/sot/commands/GiveBuilderToolCommand.java
@@ -1,0 +1,78 @@
+package com.clarkson.sot.commands;
+
+import com.clarkson.sot.events.BuilderMode;
+import com.clarkson.sot.events.SegmentBuilderKeys;
+import com.clarkson.sot.main.SoT;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * /sotbuilder — gives the player the single master segment builder tool (BLAZE_ROD).
+ * Modes are switched via /sotmode <mode> [args].
+ */
+public class GiveBuilderToolCommand implements CommandExecutor {
+
+    private final SoT plugin;
+    private final NamespacedKey toolTypeKey;
+
+    public GiveBuilderToolCommand(@NotNull SoT plugin) {
+        this.plugin = plugin;
+        this.toolTypeKey = new NamespacedKey(plugin, SegmentBuilderKeys.TOOL_TYPE);
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command,
+                             @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(Component.text("Players only.", NamedTextColor.RED));
+            return true;
+        }
+        if (!sender.hasPermission("sot.admin.builder")) {
+            sender.sendMessage(Component.text("You don't have permission to use this.", NamedTextColor.RED));
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        ItemStack tool = new ItemStack(Material.BLAZE_ROD);
+        ItemMeta meta = tool.getItemMeta();
+        if (meta == null) {
+            sender.sendMessage(Component.text("Error creating builder tool.", NamedTextColor.RED));
+            return true;
+        }
+
+        meta.displayName(Component.text("Segment Builder", NamedTextColor.GOLD));
+
+        List<Component> lore = Arrays.stream(BuilderMode.values())
+                .map(m -> Component.text("  " + m.name(), NamedTextColor.GRAY))
+                .collect(Collectors.toList());
+        lore.add(0, Component.text("Switch mode: /sotmode <mode>", NamedTextColor.YELLOW));
+        meta.lore(lore);
+
+        meta.getPersistentDataContainer().set(
+                toolTypeKey, PersistentDataType.STRING, SegmentBuilderKeys.TOOL_TYPE_VALUE);
+
+        tool.setItemMeta(meta);
+        player.getInventory().addItem(tool);
+        player.sendMessage(Component.text("Segment builder tool given. Use ", NamedTextColor.GREEN)
+                .append(Component.text("/sotmode <mode>", NamedTextColor.YELLOW))
+                .append(Component.text(" to switch modes.", NamedTextColor.GREEN)));
+        return true;
+    }
+}

--- a/src/main/java/com/clarkson/sot/commands/SaveSegmentCommand.java
+++ b/src/main/java/com/clarkson/sot/commands/SaveSegmentCommand.java
@@ -1,48 +1,58 @@
 package com.clarkson.sot.commands;
 
-import com.clarkson.sot.dungeon.segment.SegmentType;
+import com.clarkson.sot.dungeon.VaultColor;
 import com.clarkson.sot.dungeon.segment.Segment;
+import com.clarkson.sot.dungeon.segment.Segment.RelativeEntryPoint;
+import com.clarkson.sot.dungeon.segment.SegmentBound;
+import com.clarkson.sot.dungeon.segment.SegmentType;
+import com.clarkson.sot.dungeon.segment.Direction;
 import com.clarkson.sot.dungeon.segment.PlacedSegment;
-import com.clarkson.sot.main.SoT; // Your main plugin class
+import com.clarkson.sot.events.SegmentBuilderKeys;
+import com.clarkson.sot.main.SoT;
 import com.clarkson.sot.utils.StructureSaver;
 
-// WorldEdit imports
+import com.sk89q.worldedit.IncompleteRegionException;
+import com.sk89q.worldedit.LocalSession;
+import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.session.SessionManager;
-// Removed SessionOwner import as it's unused
-import com.sk89q.worldedit.IncompleteRegionException;
-import com.sk89q.worldedit.LocalSession;
-import com.sk89q.worldedit.WorldEdit;
 
-
-import org.bukkit.Bukkit;
-// Removed: import org.bukkit.ChatColor;
-import org.bukkit.Location;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
-import org.jetbrains.annotations.NotNull;
-
-// Adventure API Imports
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
-import java.util.ArrayList; // For empty lists
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.BlockDisplay;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.util.BoundingBox;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
-import java.util.stream.Collectors; // For joining segment type names
+import java.util.stream.Collectors;
 
 /**
- * Command to save a selected structure as a new Segment template.
- * Usage: /sotsavesegment <name> <type> <schematic_filename> [totalCoins]
- * NOTE: This is a basic example. It does NOT handle parsing entry points,
- * spawn points, or vault/key locations from arguments, which is complex.
- * An in-game marking tool is recommended for those features.
+ * /sotsavesegment <name> <type>
+ * <p>
+ * Scans all build-phase marker entities inside the player's WorldEdit selection,
+ * converts their positions to relative offsets from the selection's minimum corner,
+ * and saves the segment template + schematic.
+ * <p>
+ * The schematic filename is auto-derived as {@code <name>.schem}.
  */
 public class SaveSegmentCommand implements CommandExecutor {
 
@@ -50,172 +60,355 @@ public class SaveSegmentCommand implements CommandExecutor {
     private final StructureSaver structureSaver;
     private final WorldEditPlugin worldEdit;
 
-    public SaveSegmentCommand(SoT plugin) {
-        this.plugin = plugin;
-        this.structureSaver = new StructureSaver(plugin); // Instantiate the saver
+    // PDC keys
+    private final NamespacedKey BUILD_MARKER_TAG;
+    private final NamespacedKey MARKER_TYPE_KEY;
+    private final NamespacedKey DIRECTION_KEY;
+    private final NamespacedKey VAULT_COLOR_KEY;
+    private final NamespacedKey COIN_VALUE_KEY;
+    private final NamespacedKey BOUND_MIN_KEY;
+    private final NamespacedKey BOUND_MAX_KEY;
 
-        // Get WorldEdit plugin instance
+    public SaveSegmentCommand(@NotNull SoT plugin) {
+        this.plugin = plugin;
+        this.structureSaver = new StructureSaver(plugin);
+
         Plugin wep = Bukkit.getServer().getPluginManager().getPlugin("WorldEdit");
-        if (wep instanceof WorldEditPlugin) {
-            this.worldEdit = (WorldEditPlugin) wep;
-        } else {
-            this.worldEdit = null;
-            plugin.getLogger().severe("WorldEdit plugin not found or is not the correct type! /sotsavesegment will not work.");
-            // Disable the command or handle appropriately
+        this.worldEdit = (wep instanceof WorldEditPlugin) ? (WorldEditPlugin) wep : null;
+        if (this.worldEdit == null) {
+            plugin.getLogger().severe("WorldEdit not found — /sotsavesegment will not work.");
         }
+
+        BUILD_MARKER_TAG = new NamespacedKey(plugin, SegmentBuilderKeys.BUILD_MARKER_TAG);
+        MARKER_TYPE_KEY  = new NamespacedKey(plugin, SegmentBuilderKeys.MARKER_TYPE);
+        DIRECTION_KEY    = new NamespacedKey(plugin, SegmentBuilderKeys.DIRECTION);
+        VAULT_COLOR_KEY  = new NamespacedKey(plugin, SegmentBuilderKeys.VAULT_COLOR);
+        COIN_VALUE_KEY   = new NamespacedKey(plugin, SegmentBuilderKeys.COIN_VALUE);
+        BOUND_MIN_KEY    = new NamespacedKey(plugin, SegmentBuilderKeys.BOUND_MIN);
+        BOUND_MAX_KEY    = new NamespacedKey(plugin, SegmentBuilderKeys.BOUND_MAX);
     }
 
     @Override
-    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command,
+                             @NotNull String label, @NotNull String[] args) {
         if (!(sender instanceof Player)) {
-            // Use Adventure Component for console message
-            sender.sendMessage(Component.text("This command can only be run by a player.", NamedTextColor.RED));
+            sender.sendMessage(Component.text("Players only.", NamedTextColor.RED));
             return true;
         }
         if (worldEdit == null) {
-             // Use Adventure Component for player message
-             sender.sendMessage(Component.text("WorldEdit is not available. Cannot save segment.", NamedTextColor.RED));
-             return true;
+            sender.sendMessage(Component.text("WorldEdit unavailable.", NamedTextColor.RED));
+            return true;
         }
 
         Player player = (Player) sender;
 
-        // --- Argument Parsing (Basic Example) ---
-        if (args.length < 3) {
-            // Send usage message using Adventure Components
-            player.sendMessage(Component.text("Usage: /" + label + " <name> <type> <schematic_filename> [totalCoins]", NamedTextColor.RED));
-            player.sendMessage(Component.text("Example: /" + label + " my_room CORRIDOR my_room.schem 50", NamedTextColor.GRAY));
-            // TODO: List available SegmentTypes using Adventure
-            player.sendMessage(Component.text("Available types: ", NamedTextColor.GRAY)
-                .append(Component.text(String.join(", ", getSegmentTypeNames()), NamedTextColor.WHITE)));
+        if (args.length < 2) {
+            player.sendMessage(Component.text("Usage: /" + label + " <name> <type>", NamedTextColor.RED));
+            player.sendMessage(Component.text("Types: " + getTypeNames(), NamedTextColor.GRAY));
             return true;
         }
 
         String segmentName = args[0];
-        String typeStr = args[1].toUpperCase();
-        String schematicFileName = args[2];
+        SegmentType segmentType;
+        try {
+            segmentType = SegmentType.valueOf(args[1].toUpperCase());
+        } catch (IllegalArgumentException e) {
+            player.sendMessage(Component.text("Invalid type: " + args[1], NamedTextColor.RED));
+            player.sendMessage(Component.text("Valid types: " + getTypeNames(), NamedTextColor.GRAY));
+            return true;
+        }
+
+        // --- Get WorldEdit selection ---
+        Region selection;
+        Location worldOrigin;
+        BlockVector3 size;
+        BlockVector3 selMin;
+
+        try {
+            com.sk89q.worldedit.entity.Player wePlayer = BukkitAdapter.adapt(player);
+            SessionManager sm = WorldEdit.getInstance().getSessionManager();
+            LocalSession session = sm.get(wePlayer);
+            selection = session.getSelection(wePlayer.getWorld());
+            selMin = selection.getMinimumPoint();
+            BlockVector3 selMax = selection.getMaximumPoint();
+            size = selMax.subtract(selMin).add(1, 1, 1);
+            worldOrigin = BukkitAdapter.adapt(player.getWorld(), selMin);
+        } catch (IncompleteRegionException e) {
+            player.sendMessage(Component.text(
+                    "Your WorldEdit selection is incomplete. Select two points first.",
+                    NamedTextColor.RED));
+            return true;
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.SEVERE, "Error getting WE selection for " + player.getName(), e);
+            player.sendMessage(Component.text("Error reading selection.", NamedTextColor.RED));
+            return true;
+        }
+
+        // --- Collect all build marker entities inside the selection ---
+        BoundingBox bbox = new BoundingBox(
+                selMin.x(), selMin.y(), selMin.z(),
+                selMin.x() + size.x(), selMin.y() + size.y(), selMin.z() + size.z()
+        );
+        Collection<Entity> entities = player.getWorld().getNearbyEntities(bbox,
+                e -> e instanceof BlockDisplay
+                  && e.getPersistentDataContainer().has(BUILD_MARKER_TAG, PersistentDataType.BYTE));
+
+        // --- Parse markers into Segment fields ---
+        List<RelativeEntryPoint> entryPoints   = new ArrayList<>();
+        List<BlockVector3> sandSpawns          = new ArrayList<>();
+        List<BlockVector3> itemSpawns          = new ArrayList<>();
+        List<BlockVector3> coinSpawns          = new ArrayList<>();
+        List<BlockVector3> sandSacrifices      = new ArrayList<>();
+        List<BlockVector3> mobSpawners         = new ArrayList<>();
+        List<SegmentBound> gates               = new ArrayList<>();
+
+        SegmentBound vaultDoorBound            = null;
+        BlockVector3 vaultOffset               = null;
+        BlockVector3 keyOffset                 = null;
+        BlockVector3 leverOffset               = null;
+        VaultColor containedVault              = null;
+        VaultColor containedVaultKey           = null;
+
         int totalCoins = 0;
-        if (args.length >= 4) {
-            try {
-                totalCoins = Integer.parseInt(args[3]);
-            } catch (NumberFormatException e) {
-                // Use Adventure Component for error message
-                player.sendMessage(Component.text("Invalid number for totalCoins: " + args[3], NamedTextColor.RED));
-                return true;
+
+        for (Entity entity : entities) {
+            PersistentDataContainer pdc = entity.getPersistentDataContainer();
+            String type = pdc.getOrDefault(MARKER_TYPE_KEY, PersistentDataType.STRING, "");
+
+            // Skip frame entities — data is on the anchor only
+            if ("ENTRY_FRAME".equals(type) || "BOUND_FRAME".equals(type)
+                    || "BOUND_CORNER1".equals(type)) {
+                continue;
+            }
+
+            BlockVector3 relPos = toRelative(entity.getLocation(), selMin);
+
+            switch (type) {
+                case "ENTRY_POINT": {
+                    String dirStr = pdc.get(DIRECTION_KEY, PersistentDataType.STRING);
+                    if (dirStr != null) {
+                        try {
+                            Direction dir = Direction.valueOf(dirStr);
+                            entryPoints.add(new RelativeEntryPoint(relPos, dir));
+                        } catch (IllegalArgumentException ex) {
+                            warn(player, "Entry point with unknown direction '" + dirStr + "' — skipped.");
+                        }
+                    }
+                    break;
+                }
+                case "VAULT_DOOR": {
+                    SegmentBound bound = readBound(pdc, selMin);
+                    if (bound != null) {
+                        if (vaultDoorBound != null) {
+                            warn(player, "Multiple VAULT_DOOR markers found — using first.");
+                        } else {
+                            vaultDoorBound = bound;
+                            String colorStr = pdc.get(VAULT_COLOR_KEY, PersistentDataType.STRING);
+                            if (colorStr != null) {
+                                try { containedVault = VaultColor.valueOf(colorStr); }
+                                catch (IllegalArgumentException ex) {
+                                    warn(player, "VAULT_DOOR has unknown color '" + colorStr + "'.");
+                                }
+                            }
+                        }
+                    }
+                    break;
+                }
+                case "VAULT_MARKER": {
+                    if (vaultOffset != null) {
+                        warn(player, "Multiple VAULT_MARKER entities — using first.");
+                    } else {
+                        vaultOffset = relPos;
+                        if (containedVault == null) {
+                            String colorStr = pdc.get(VAULT_COLOR_KEY, PersistentDataType.STRING);
+                            if (colorStr != null) {
+                                try { containedVault = VaultColor.valueOf(colorStr); }
+                                catch (IllegalArgumentException ignored) {}
+                            }
+                        }
+                    }
+                    break;
+                }
+                case "KEY_SPAWN": {
+                    if (keyOffset != null) {
+                        warn(player, "Multiple KEY_SPAWN entities — using first.");
+                    } else {
+                        keyOffset = relPos;
+                        String colorStr = pdc.get(VAULT_COLOR_KEY, PersistentDataType.STRING);
+                        if (colorStr != null) {
+                            try { containedVaultKey = VaultColor.valueOf(colorStr); }
+                            catch (IllegalArgumentException ignored) {}
+                        }
+                    }
+                    break;
+                }
+                case "GATE": {
+                    SegmentBound bound = readBound(pdc, selMin);
+                    if (bound != null) gates.add(bound);
+                    break;
+                }
+                case "LEVER": {
+                    if (leverOffset != null) {
+                        warn(player, "Multiple LEVER markers — only one allowed. Using first.");
+                    } else {
+                        leverOffset = relPos;
+                    }
+                    break;
+                }
+                case "SAND_SPAWN":
+                    sandSpawns.add(relPos);
+                    break;
+                case "SAND_SACRIFICE":
+                    sandSacrifices.add(relPos);
+                    break;
+                case "COIN_SPAWN": {
+                    coinSpawns.add(relPos);
+                    Integer val = pdc.get(COIN_VALUE_KEY, PersistentDataType.INTEGER);
+                    totalCoins += (val != null) ? val : 10;
+                    break;
+                }
+                case "ITEM_SPAWN":
+                    itemSpawns.add(relPos);
+                    break;
+                case "MOB_SPAWNER":
+                    mobSpawners.add(relPos);
+                    break;
+                default:
+                    if (!type.isEmpty()) {
+                        plugin.getLogger().fine("[SaveSegment] Unknown marker type '" + type + "' — skipped.");
+                    }
+                    break;
             }
         }
 
-        // Validate SegmentType
-        SegmentType segmentType;
-        try {
-            segmentType = SegmentType.valueOf(typeStr);
-        } catch (IllegalArgumentException e) {
-            // Use Adventure Component for error message
-            player.sendMessage(Component.text("Invalid segment type: " + args[1], NamedTextColor.RED));
-            player.sendMessage(Component.text("Valid types are: ", NamedTextColor.GRAY)
-                .append(Component.text(String.join(", ", getSegmentTypeNames()), NamedTextColor.WHITE)));
+        // --- Validate ---
+        if (!gates.isEmpty() && leverOffset == null) {
+            player.sendMessage(Component.text(
+                    "Save failed: segment has " + gates.size() + " gate(s) but no LEVER marker.",
+                    NamedTextColor.RED));
             return true;
         }
-
-        // Validate schematic filename format (basic)
-        if (!schematicFileName.toLowerCase().endsWith(".schem") && !schematicFileName.toLowerCase().endsWith(".schematic")) {
-             // Allow both common extensions
-             schematicFileName += ".schem"; // Append default if missing
-             // Use Adventure Component for info message
-             player.sendMessage(Component.text("Appending '.schem' to schematic filename.", NamedTextColor.YELLOW));
+        if (gates.isEmpty() && leverOffset != null) {
+            player.sendMessage(Component.text(
+                    "Warning: LEVER marker present but no gates found.", NamedTextColor.YELLOW));
         }
 
-        // --- Get WorldEdit Selection ---
-        Region selection;
-        Location worldOrigin; // Absolute minimum point of the selection
-        BlockVector3 size;
+        // --- Print summary ---
+        player.sendMessage(Component.text("--- Segment Marker Summary ---", NamedTextColor.GOLD));
+        player.sendMessage(info("Entry Points",    entryPoints.size()));
+        player.sendMessage(info("Sand Spawns",     sandSpawns.size()));
+        player.sendMessage(info("Item Spawns",     itemSpawns.size()));
+        player.sendMessage(info("Coin Spawns",     coinSpawns.size())
+                .append(Component.text(" (total value: " + totalCoins + ")", NamedTextColor.GRAY)));
+        player.sendMessage(info("Sand Sacrifices", sandSacrifices.size()));
+        player.sendMessage(info("Mob Spawners",    mobSpawners.size()));
+        player.sendMessage(info("Gates",           gates.size()));
+        player.sendMessage(Component.text("  Lever: ", NamedTextColor.WHITE)
+                .append(Component.text(leverOffset != null ? "yes" : "none",
+                        leverOffset != null ? NamedTextColor.GREEN : NamedTextColor.GRAY)));
+        player.sendMessage(Component.text("  Vault Door: ", NamedTextColor.WHITE)
+                .append(Component.text(vaultDoorBound != null
+                        ? (containedVault != null ? containedVault.name() : "color unknown")
+                        : "none",
+                        vaultDoorBound != null ? NamedTextColor.AQUA : NamedTextColor.GRAY)));
+        player.sendMessage(Component.text("  Vault Marker: ", NamedTextColor.WHITE)
+                .append(Component.text(vaultOffset != null ? "yes" : "none",
+                        vaultOffset != null ? NamedTextColor.GREEN : NamedTextColor.GRAY)));
+        player.sendMessage(Component.text("  Key Spawn: ", NamedTextColor.WHITE)
+                .append(Component.text(keyOffset != null
+                        ? (containedVaultKey != null ? containedVaultKey.name() : "color unknown")
+                        : "none",
+                        keyOffset != null ? NamedTextColor.AQUA : NamedTextColor.GRAY)));
 
-        try {
-            // Adapt player for WorldEdit session
-             com.sk89q.worldedit.entity.Player wePlayer = BukkitAdapter.adapt(player);
-             SessionManager sessionManager = WorldEdit.getInstance().getSessionManager();
-             LocalSession localSession = sessionManager.get(wePlayer);
-
-            // Get the selection from the player's session
-            selection = localSession.getSelection(wePlayer.getWorld()); // Pass world context
-            worldOrigin = BukkitAdapter.adapt(player.getWorld(), selection.getMinimumPoint()); // Convert WE min point to Bukkit Location
-
-            // Calculate size
-            BlockVector3 min = selection.getMinimumPoint();
-            BlockVector3 max = selection.getMaximumPoint();
-            size = max.subtract(min).add(1, 1, 1); // Size is max - min + 1
-
-        } catch (IncompleteRegionException e) {
-            // Use Adventure Component for error message
-            player.sendMessage(Component.text("Your WorldEdit selection is incomplete. Please select two points.", NamedTextColor.RED));
-            return true;
-        } catch (Exception e) {
-            plugin.getLogger().log(Level.SEVERE, "Error getting WorldEdit selection for " + player.getName(), e);
-            // Use Adventure Component for error message
-            player.sendMessage(Component.text("An error occurred while getting your WorldEdit selection.", NamedTextColor.RED));
-            return true;
-        }
-
-        // --- Create Segment Template (Basic - Missing complex data) ---
+        // --- Build Segment ---
+        String schematicFileName = segmentName + ".schem";
         Segment segmentTemplate;
         try {
-            // TODO: Passing empty lists for entry/spawn points and null for vault/key info.
-            // A real implementation needs to get this data, likely via in-game marking or more args.
             segmentTemplate = new Segment(
-                    segmentName,
-                    segmentType,
-                    schematicFileName,
-                    size,
-                    new ArrayList<>(), // Empty Entry Points - NEEDS IMPLEMENTATION
-                    new ArrayList<>(), // Empty Sand Spawns - NEEDS IMPLEMENTATION
-                    new ArrayList<>(), // Empty Item Spawns - NEEDS IMPLEMENTATION
-                    new ArrayList<>(), // Empty Coin Spawns - NEEDS IMPLEMENTATION
-                    totalCoins,
-                    null, // No contained vault - NEEDS IMPLEMENTATION
-                    null, // No contained key - NEEDS IMPLEMENTATION
-                    null, // No vault offset - NEEDS IMPLEMENTATION
-                    null  // No key offset - NEEDS IMPLEMENTATION
+                    segmentName, segmentType, schematicFileName, size,
+                    entryPoints, sandSpawns, itemSpawns, coinSpawns,
+                    totalCoins, containedVault, containedVaultKey,
+                    vaultOffset, keyOffset,
+                    vaultDoorBound, gates, leverOffset,
+                    sandSacrifices, mobSpawners
             );
         } catch (Exception e) {
-             plugin.getLogger().log(Level.SEVERE, "Error creating Segment template object for " + segmentName, e);
-             // Use Adventure Component for error message
-             player.sendMessage(Component.text("An error occurred creating the segment template data.", NamedTextColor.RED));
-             return true;
+            plugin.getLogger().log(Level.SEVERE, "Error constructing Segment for " + segmentName, e);
+            player.sendMessage(Component.text("Error creating segment data.", NamedTextColor.RED));
+            return true;
         }
 
+        PlacedSegment placed = new PlacedSegment(segmentTemplate, worldOrigin, 0);
 
-        // --- Create PlacedSegment ---
-        // Depth is 0 as we are saving a base template outside generation context
-        PlacedSegment placedSegment = new PlacedSegment(segmentTemplate, worldOrigin, 0);
-
-        // --- Call StructureSaver ---
-        // Use Adventure Component for status message
-        player.sendMessage(Component.text("Attempting to save segment '" + segmentName + "'...", NamedTextColor.YELLOW));
-        boolean success = structureSaver.saveStructure(placedSegment);
+        player.sendMessage(Component.text("Saving segment '" + segmentName + "'...", NamedTextColor.YELLOW));
+        boolean success = structureSaver.saveStructure(placed);
 
         if (success) {
-            // Use Adventure Components for success message
-            player.sendMessage(Component.text("Segment '" + segmentName + "' saved successfully!", NamedTextColor.GREEN));
-            player.sendMessage(Component.text("Schematic: ", NamedTextColor.GREEN)
-                .append(Component.text(schematicFileName, NamedTextColor.WHITE)));
-            player.sendMessage(Component.text("Metadata: ", NamedTextColor.GREEN)
-                .append(Component.text(segmentName + ".json", NamedTextColor.WHITE)));
-            player.sendMessage(Component.text("Reload templates or restart server to use the new segment.", NamedTextColor.YELLOW));
-            // Consider adding automatic reloading if feasible
+            player.sendMessage(Component.text("Segment saved: " + segmentName + ".json + "
+                    + schematicFileName, NamedTextColor.GREEN));
+            player.sendMessage(Component.text(
+                    "Use /sotreloadsegments or restart to use the new segment.", NamedTextColor.YELLOW));
         } else {
-            // Use Adventure Component for failure message
-            player.sendMessage(Component.text("Failed to save segment '" + segmentName + "'. Check console for errors.", NamedTextColor.RED));
+            player.sendMessage(Component.text(
+                    "Failed to save segment. Check console for errors.", NamedTextColor.RED));
         }
-
         return true;
     }
 
-    // Helper to get enum names (replace with your actual enum path)
-    private List<String> getSegmentTypeNames() {
-        // Using streams for a slightly more modern approach
-        return List.of(SegmentType.values()) // Get all enum values
-                   .stream()                 // Create a stream
-                   .map(Enum::name)          // Map each enum value to its name (String)
-                   .collect(Collectors.toList()); // Collect the names into a List
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Converts an absolute world Location to a relative BlockVector3 offset from selMin. */
+    private BlockVector3 toRelative(Location loc, BlockVector3 selMin) {
+        return BlockVector3.at(
+                loc.getBlockX() - selMin.x(),
+                loc.getBlockY() - selMin.y(),
+                loc.getBlockZ() - selMin.z()
+        );
+    }
+
+    /** Reads a SegmentBound from a bound anchor entity's PDC, converting to relative coords. */
+    @Nullable
+    private SegmentBound readBound(PersistentDataContainer pdc, BlockVector3 selMin) {
+        String minStr = pdc.get(BOUND_MIN_KEY, PersistentDataType.STRING);
+        String maxStr = pdc.get(BOUND_MAX_KEY, PersistentDataType.STRING);
+        if (minStr == null || maxStr == null) return null;
+        try {
+            BlockVector3 absMin = parseVec(minStr);
+            BlockVector3 absMax = parseVec(maxStr);
+            BlockVector3 relMin = absMin.subtract(selMin);
+            BlockVector3 relMax = absMax.subtract(selMin);
+            return new SegmentBound(relMin, relMax);
+        } catch (Exception e) {
+            plugin.getLogger().warning("[SaveSegment] Failed to parse bound coords: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private BlockVector3 parseVec(String csv) {
+        String[] parts = csv.split(",");
+        return BlockVector3.at(
+                Integer.parseInt(parts[0].trim()),
+                Integer.parseInt(parts[1].trim()),
+                Integer.parseInt(parts[2].trim())
+        );
+    }
+
+    private void warn(Player player, String msg) {
+        player.sendMessage(Component.text("Warning: " + msg, NamedTextColor.YELLOW));
+        plugin.getLogger().warning("[SaveSegment] " + msg);
+    }
+
+    private Component info(String label, int count) {
+        return Component.text("  " + label + ": ", NamedTextColor.WHITE)
+                .append(Component.text(String.valueOf(count),
+                        count > 0 ? NamedTextColor.GREEN : NamedTextColor.GRAY));
+    }
+
+    private String getTypeNames() {
+        return java.util.Arrays.stream(SegmentType.values())
+                .map(Enum::name)
+                .collect(Collectors.joining(", "));
     }
 }

--- a/src/main/java/com/clarkson/sot/commands/SetBuilderModeCommand.java
+++ b/src/main/java/com/clarkson/sot/commands/SetBuilderModeCommand.java
@@ -1,0 +1,169 @@
+package com.clarkson.sot.commands;
+
+import com.clarkson.sot.dungeon.VaultColor;
+import com.clarkson.sot.events.BuilderMode;
+import com.clarkson.sot.events.BuilderSessionManager;
+import com.clarkson.sot.events.PlayerBuilderSession;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * /sotmode <mode> [color|value]
+ * Switches the builder tool mode for the calling player.
+ *
+ * Examples:
+ *   /sotmode ENTRY_POINT
+ *   /sotmode VAULT_DOOR BLUE
+ *   /sotmode KEY_SPAWN GOLD
+ *   /sotmode COIN_SPAWN 50
+ */
+public class SetBuilderModeCommand implements CommandExecutor, TabCompleter {
+
+    private final BuilderSessionManager sessionManager;
+
+    // Modes that require a VaultColor second argument.
+    private static final List<BuilderMode> COLOR_MODES = Arrays.asList(
+            BuilderMode.VAULT_DOOR, BuilderMode.VAULT_MARKER, BuilderMode.KEY_SPAWN);
+
+    public SetBuilderModeCommand(@NotNull BuilderSessionManager sessionManager) {
+        this.sessionManager = sessionManager;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command,
+                             @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(Component.text("Players only.", NamedTextColor.RED));
+            return true;
+        }
+        if (!sender.hasPermission("sot.admin.builder")) {
+            sender.sendMessage(Component.text("No permission.", NamedTextColor.RED));
+            return true;
+        }
+        if (args.length < 1) {
+            sendUsage((Player) sender, label);
+            return true;
+        }
+
+        Player player = (Player) sender;
+        PlayerBuilderSession session = sessionManager.getSession(player);
+
+        // --- Parse mode ---
+        BuilderMode newMode;
+        try {
+            newMode = BuilderMode.valueOf(args[0].toUpperCase());
+        } catch (IllegalArgumentException e) {
+            player.sendMessage(Component.text("Unknown mode: " + args[0], NamedTextColor.RED));
+            sendUsage(player, label);
+            return true;
+        }
+
+        // --- If switching away from a bound mode that has a pending corner, cancel it ---
+        if (session.getMode().isBoundMode() && session.getPendingBoundCorner() != null) {
+            // Remove the temp first-corner entity if it still exists
+            if (session.getPendingCornerEntityId() != null) {
+                player.getWorld().getEntities().stream()
+                        .filter(e -> e.getUniqueId().equals(session.getPendingCornerEntityId()))
+                        .forEach(Entity::remove);
+            }
+            session.clearPendingBound();
+            player.sendMessage(Component.text("Pending bound selection cancelled.", NamedTextColor.YELLOW));
+        }
+
+        // --- Parse optional second argument (VaultColor or coin value) ---
+        VaultColor newColor = null;
+        if (COLOR_MODES.contains(newMode)) {
+            if (args.length < 2) {
+                player.sendMessage(Component.text(newMode.getDisplayName()
+                        + " requires a color: BLUE, RED, GREEN, GOLD", NamedTextColor.RED));
+                return true;
+            }
+            try {
+                newColor = VaultColor.valueOf(args[1].toUpperCase());
+            } catch (IllegalArgumentException e) {
+                player.sendMessage(Component.text("Invalid color: " + args[1]
+                        + ". Use BLUE, RED, GREEN, or GOLD.", NamedTextColor.RED));
+                return true;
+            }
+        }
+
+        int newCoinValue = session.getCoinValue();
+        if (newMode == BuilderMode.COIN_SPAWN && args.length >= 2) {
+            try {
+                newCoinValue = Integer.parseInt(args[1]);
+                if (newCoinValue < 1) throw new NumberFormatException();
+            } catch (NumberFormatException e) {
+                player.sendMessage(Component.text("Invalid coin value: " + args[1]
+                        + ". Must be a positive integer.", NamedTextColor.RED));
+                return true;
+            }
+        }
+
+        // --- Apply to session ---
+        session.setMode(newMode);
+        session.setVaultColor(newColor);
+        session.setCoinValue(newCoinValue);
+
+        // --- Feedback ---
+        Component msg = Component.text("Mode: ", NamedTextColor.GREEN)
+                .append(Component.text(newMode.getDisplayName(), NamedTextColor.YELLOW));
+        if (newColor != null) {
+            msg = msg.append(Component.text(" (" + newColor.name() + ")", NamedTextColor.AQUA));
+        }
+        if (newMode == BuilderMode.COIN_SPAWN) {
+            msg = msg.append(Component.text(" value=" + newCoinValue, NamedTextColor.GOLD));
+        }
+        player.sendActionBar(msg);
+        player.sendMessage(msg);
+        player.sendMessage(Component.text(newMode.getHint(), NamedTextColor.GRAY));
+        return true;
+    }
+
+    @Override
+    @Nullable
+    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command,
+                                      @NotNull String alias, @NotNull String[] args) {
+        if (args.length == 1) {
+            return Arrays.stream(BuilderMode.values())
+                    .map(BuilderMode::name)
+                    .filter(n -> n.startsWith(args[0].toUpperCase()))
+                    .collect(Collectors.toList());
+        }
+        if (args.length == 2) {
+            BuilderMode mode = null;
+            try { mode = BuilderMode.valueOf(args[0].toUpperCase()); } catch (IllegalArgumentException ignored) {}
+            if (mode != null && COLOR_MODES.contains(mode)) {
+                return Arrays.stream(VaultColor.values())
+                        .map(Enum::name)
+                        .filter(n -> n.startsWith(args[1].toUpperCase()))
+                        .collect(Collectors.toList());
+            }
+            if (mode == BuilderMode.COIN_SPAWN) {
+                return List.of("1", "5", "10", "25", "50", "100");
+            }
+        }
+        return new ArrayList<>();
+    }
+
+    private void sendUsage(Player player, String label) {
+        player.sendMessage(Component.text("Usage: /" + label + " <mode> [color|value]", NamedTextColor.YELLOW));
+        player.sendMessage(Component.text("Modes: " +
+                Arrays.stream(BuilderMode.values()).map(BuilderMode::name)
+                        .collect(Collectors.joining(", ")), NamedTextColor.GRAY));
+    }
+}

--- a/src/main/java/com/clarkson/sot/dungeon/DungeonGenerator.java
+++ b/src/main/java/com/clarkson/sot/dungeon/DungeonGenerator.java
@@ -466,12 +466,13 @@ public class DungeonGenerator {
                  }
              }
          }
-         // Example: Prioritize Gold Key in Lava Parkour
+         // Prioritize Gold Key: the gold key room is the unique segment where containedVaultKey == GOLD.
+         // No type filter needed — the key metadata alone identifies the correct segment.
          if (!keysPlacedInDFS.contains(VaultColor.GOLD)) {
               MinMax range = KEY_DEPTH_RANGES.get(VaultColor.GOLD);
               if (range != null && currentDepth >= range.min && currentDepth <= range.max) {
                   List<Segment> keyCandidates = candidates.stream()
-                          .filter(s -> s.getType() == SegmentType.LAVA_PARKOUR && s.getContainedVaultKey() == VaultColor.GOLD)
+                          .filter(s -> s.getContainedVaultKey() == VaultColor.GOLD)
                           .collect(Collectors.toList());
                   if (!keyCandidates.isEmpty()) {
                       plugin.getLogger().finest("Prioritizing Gold Key placement at depth " + currentDepth);

--- a/src/main/java/com/clarkson/sot/dungeon/segment/Segment.java
+++ b/src/main/java/com/clarkson/sot/dungeon/segment/Segment.java
@@ -1,9 +1,8 @@
-package com.clarkson.sot.dungeon.segment; // Assuming this package
+package com.clarkson.sot.dungeon.segment;
 
-// Assuming VaultColor and SegmentType are in dungeon package
 import com.clarkson.sot.dungeon.VaultColor;
 
-import com.sk89q.worldedit.math.BlockVector3; // Make sure this is imported
+import com.sk89q.worldedit.math.BlockVector3;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -15,231 +14,185 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Represents a world-independent template or blueprint for a dungeon segment.
- * Stores metadata (including type, vault/key info), relative locations
- * of features (entry points, spawns, vault/key offsets), dimensions, and a link
- * to the schematic file. All positions are relative to the segment's conceptual
- * origin (usually its minimum corner).
- * Segment characteristics like Hub, Puzzle Room, Lava Parkour are now determined by SegmentType.
+ * World-independent template for a dungeon segment. All positions are relative
+ * to the segment's minimum corner (origin).
  */
 public class Segment {
 
     // --- Core Identification & Structure ---
     private final String name;
-    private final SegmentType type; // General category (e.g., HUB, PUZZLE_ROOM, LAVA_PARKOUR, CORRIDOR)
+    private final SegmentType type;
     private final String schematicFileName;
-    private final BlockVector3 size; // Width(X), Height(Y), Length(Z)
+    private final BlockVector3 size;
     private final List<RelativeEntryPoint> entryPoints;
 
     // --- Feature Spawn Locations (Relative) ---
     private final List<BlockVector3> sandSpawnLocations;
     private final List<BlockVector3> itemSpawnLocations;
     private final List<BlockVector3> coinSpawnLocations;
+    private final List<BlockVector3> sandSacrificeLocations;
+    private final List<BlockVector3> mobSpawnerLocations;
 
-    // --- Gameplay Metadata ---
-    private final int totalCoins; // Base number of coins expected (approximate)
-    // Removed: coinMultiplier - Coin scaling might now depend on PlacedSegment.depth
-    // Removed: isHub, isPuzzleRoom, isLavaParkour - Now inferred from 'type' field
-    private final VaultColor containedVault; // Which vault entrance is in this segment (null if none)
-    private final VaultColor containedVaultKey; // Which vault key is in this segment (null if none)
-    @Nullable private final BlockVector3 vaultLocationOffset; // Relative position of the vault marker block, if containedVault is not null
-    @Nullable private final BlockVector3 keyLocationOffset;   // Relative position of the key spawn, if containedVaultKey is not null
+    // --- Vault / Key Metadata ---
+    private final int totalCoins;
+    @Nullable private final VaultColor containedVault;
+    @Nullable private final VaultColor containedVaultKey;
+    @Nullable private final BlockVector3 vaultLocationOffset;
+    @Nullable private final BlockVector3 keyLocationOffset;
 
+    // --- Door / Gate / Lever ---
+    /** Vault door opening bounds, null if this segment has no vault door. */
+    @Nullable private final SegmentBound vaultDoorBound;
+    /** All gate openings in this segment (may be empty). */
+    private final List<SegmentBound> gates;
+    /** Lever position; must be present when {@code gates} is non-empty. */
+    @Nullable private final BlockVector3 leverOffset;
 
     /**
-     * Constructor for creating a Segment template.
-     * Values are typically loaded from JSON metadata.
-     *
-     * @param name                Unique name of the segment template.
-     * @param type                General category/type of the segment (e.g., HUB, PUZZLE_ROOM).
-     * @param schematicFileName   Filename of the associated schematic (e.g., "my_segment.schem").
-     * @param size                Dimensions (width, height, length) of the segment.
-     * @param entryPoints         List of entry points with relative positions and directions.
-     * @param sandSpawnLocations  List of relative spawn locations for sand.
-     * @param itemSpawnLocations  List of relative spawn locations for items.
-     * @param coinSpawnLocations  List of relative spawn locations for coins.
-     * @param totalCoins          Approximate total base coin value in the segment.
-     * @param containedVault      The color of the vault entrance within this segment, or null.
-     * @param containedVaultKey   The color of the vault key found within this segment, or null.
-     * @param vaultLocationOffset Relative offset (from segment origin) of the vault marker block, if containedVault is not null.
-     * @param keyLocationOffset   Relative offset (from segment origin) of the key spawn location, if containedVaultKey is not null.
+     * Full constructor. Called by SaveSegmentCommand and StructureLoader.
      */
     public Segment(
-            @NotNull String name,
-            @Nullable SegmentType type, // Type is now crucial
-            @NotNull String schematicFileName,
-            @NotNull BlockVector3 size,
-            @NotNull List<RelativeEntryPoint> entryPoints,
-            @NotNull List<BlockVector3> sandSpawnLocations,
-            @NotNull List<BlockVector3> itemSpawnLocations,
-            @NotNull List<BlockVector3> coinSpawnLocations,
+            @NotNull  String name,
+            @Nullable SegmentType type,
+            @NotNull  String schematicFileName,
+            @NotNull  BlockVector3 size,
+            @NotNull  List<RelativeEntryPoint> entryPoints,
+            @NotNull  List<BlockVector3> sandSpawnLocations,
+            @NotNull  List<BlockVector3> itemSpawnLocations,
+            @NotNull  List<BlockVector3> coinSpawnLocations,
             int totalCoins,
             @Nullable VaultColor containedVault,
             @Nullable VaultColor containedVaultKey,
             @Nullable BlockVector3 vaultLocationOffset,
-            @Nullable BlockVector3 keyLocationOffset
+            @Nullable BlockVector3 keyLocationOffset,
+            // New fields
+            @Nullable SegmentBound vaultDoorBound,
+            @NotNull  List<SegmentBound> gates,
+            @Nullable BlockVector3 leverOffset,
+            @NotNull  List<BlockVector3> sandSacrificeLocations,
+            @NotNull  List<BlockVector3> mobSpawnerLocations
     ) {
-        // --- Basic Validation ---
-        Objects.requireNonNull(name, "Segment name cannot be null");
-        Objects.requireNonNull(schematicFileName, "Schematic filename cannot be null");
-        // Removed null checks for booleans
-        // ... other null checks ...
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(schematicFileName, "schematicFileName");
         if (name.trim().isEmpty()) throw new IllegalArgumentException("Segment name cannot be empty");
-        // ... other validation ...
-        if (size.x() <= 0 || size.y() <= 0 || size.z() <= 0) throw new IllegalArgumentException("Segment dimensions must be positive");
+        if (size.x() <= 0 || size.y() <= 0 || size.z() <= 0)
+            throw new IllegalArgumentException("Segment dimensions must be positive");
 
-        // Validation: Offset should only be present if the corresponding item is present
-        if (containedVault == null && vaultLocationOffset != null) {
-            System.err.println("Warning: Segment '" + name + "' has vaultLocationOffset but containedVault is null.");
-            // vaultLocationOffset = null; // Optionally nullify
-        }
-        if (containedVaultKey == null && keyLocationOffset != null) {
-             System.err.println("Warning: Segment '" + name + "' has keyLocationOffset but containedVaultKey is null.");
-             // keyLocationOffset = null; // Optionally nullify
-        }
-
-
-        // --- Assign Fields ---
-        this.name = name;
-        this.type = type; // Assign the crucial type
-        this.schematicFileName = schematicFileName;
-        this.size = size;
-        this.entryPoints = new ArrayList<>(entryPoints);
-        this.sandSpawnLocations = new ArrayList<>(sandSpawnLocations);
-        this.itemSpawnLocations = new ArrayList<>(itemSpawnLocations);
-        this.coinSpawnLocations = new ArrayList<>(coinSpawnLocations);
-        this.totalCoins = totalCoins;
-        // Removed assignments for: coinMultiplier, isHub, isPuzzleRoom, isLavaParkour
-
-        // Assign Metadata Fields
-        this.containedVault = containedVault;
-        this.containedVaultKey = containedVaultKey;
-        // Assign Offset Fields
-        this.vaultLocationOffset = vaultLocationOffset;
-        this.keyLocationOffset = keyLocationOffset;
+        this.name                   = name;
+        this.type                   = type;
+        this.schematicFileName      = schematicFileName;
+        this.size                   = size;
+        this.entryPoints            = new ArrayList<>(entryPoints);
+        this.sandSpawnLocations     = new ArrayList<>(sandSpawnLocations);
+        this.itemSpawnLocations     = new ArrayList<>(itemSpawnLocations);
+        this.coinSpawnLocations     = new ArrayList<>(coinSpawnLocations);
+        this.totalCoins             = totalCoins;
+        this.containedVault         = containedVault;
+        this.containedVaultKey      = containedVaultKey;
+        this.vaultLocationOffset    = vaultLocationOffset;
+        this.keyLocationOffset      = keyLocationOffset;
+        this.vaultDoorBound         = vaultDoorBound;
+        this.gates                  = new ArrayList<>(gates);
+        this.leverOffset            = leverOffset;
+        this.sandSacrificeLocations = new ArrayList<>(sandSacrificeLocations);
+        this.mobSpawnerLocations    = new ArrayList<>(mobSpawnerLocations);
     }
 
-    // --- Getters for Core Info ---
-    @NotNull public String getName() { return name; }
-    @Nullable public SegmentType getType() { return type; } // Getter for the type
-    @NotNull public String getSchematicFileName() { return schematicFileName; }
-    @NotNull public BlockVector3 getSize() { return size; }
-    @NotNull public List<RelativeEntryPoint> getEntryPoints() { return Collections.unmodifiableList(entryPoints); }
+    // --- Core getters ---
+    @NotNull  public String getName()               { return name; }
+    @Nullable public SegmentType getType()          { return type; }
+    @NotNull  public String getSchematicFileName()  { return schematicFileName; }
+    @NotNull  public BlockVector3 getSize()         { return size; }
+    @NotNull  public List<RelativeEntryPoint> getEntryPoints() {
+        return Collections.unmodifiableList(entryPoints);
+    }
 
-    // --- Getters for Spawn Locations ---
-    @NotNull public List<BlockVector3> getSandSpawnLocations() { return Collections.unmodifiableList(sandSpawnLocations); }
-    @NotNull public List<BlockVector3> getItemSpawnLocations() { return Collections.unmodifiableList(itemSpawnLocations); }
-    @NotNull public List<BlockVector3> getCoinSpawnLocations() { return Collections.unmodifiableList(coinSpawnLocations); }
+    // --- Spawn location getters ---
+    @NotNull public List<BlockVector3> getSandSpawnLocations()     { return Collections.unmodifiableList(sandSpawnLocations); }
+    @NotNull public List<BlockVector3> getItemSpawnLocations()     { return Collections.unmodifiableList(itemSpawnLocations); }
+    @NotNull public List<BlockVector3> getCoinSpawnLocations()     { return Collections.unmodifiableList(coinSpawnLocations); }
+    @NotNull public List<BlockVector3> getSandSacrificeLocations() { return Collections.unmodifiableList(sandSacrificeLocations); }
+    @NotNull public List<BlockVector3> getMobSpawnerLocations()    { return Collections.unmodifiableList(mobSpawnerLocations); }
 
-    // --- Getters for Gameplay Metadata ---
+    // --- Vault / key getters ---
     public int getTotalCoins() { return totalCoins; }
-    // Removed getters: getCoinMultiplier(), isHub(), isPuzzleRoom(), isLavaParkour()
-    @Nullable public VaultColor getContainedVault() { return containedVault; }
+    @Nullable public VaultColor getContainedVault()    { return containedVault; }
     @Nullable public VaultColor getContainedVaultKey() { return containedVaultKey; }
 
-    /**
-     * Gets the relative offset (from segment origin) for the vault marker block,
-     * if this segment contains a vault entrance (i.e., getContainedVault() is not null).
-     *
-     * @return The relative BlockVector3 offset, or null if no vault or offset is defined.
-     */
     @Nullable
     public BlockVector3 getVaultOffset() {
-        // Return the offset only if a vault is actually supposed to be contained
-        return (this.containedVault != null) ? this.vaultLocationOffset : null;
+        return (containedVault != null) ? vaultLocationOffset : null;
     }
 
-    /**
-     * Gets the relative offset (from segment origin) for the vault key spawn location,
-     * if this segment contains a vault key (i.e., getContainedVaultKey() is not null).
-     *
-     * @return The relative BlockVector3 offset, or null if no key or offset is defined.
-     */
     @Nullable
     public BlockVector3 getKeyOffset() {
-        // Return the offset only if a key is actually supposed to be contained
-        return (this.containedVaultKey != null) ? this.keyLocationOffset : null;
+        return (containedVaultKey != null) ? keyLocationOffset : null;
     }
 
+    // --- Door / gate / lever getters ---
+    @Nullable public SegmentBound getVaultDoorBound()  { return vaultDoorBound; }
+    @NotNull  public List<SegmentBound> getGates()     { return Collections.unmodifiableList(gates); }
+    @Nullable public BlockVector3 getLeverOffset()     { return leverOffset; }
 
-    // --- Template-related Logic ---
+    // --- Entry-point helpers ---
     public boolean hasEntryPointInDirection(@NotNull Direction dir) {
-        Objects.requireNonNull(dir, "Direction cannot be null");
-        for (RelativeEntryPoint ep : this.entryPoints) {
-            if (ep.getDirection() == dir) {
-                return true;
-            }
+        Objects.requireNonNull(dir);
+        for (RelativeEntryPoint ep : entryPoints) {
+            if (ep.getDirection() == dir) return true;
         }
         return false;
     }
 
     @Nullable
     public RelativeEntryPoint findEntryPointByDirection(@NotNull Direction direction) {
-        Objects.requireNonNull(direction, "Direction cannot be null");
-         for (RelativeEntryPoint ep : this.entryPoints) {
-             if (ep.getDirection() == direction) {
-                 return ep;
-             }
-         }
-         return null;
-     }
+        Objects.requireNonNull(direction);
+        for (RelativeEntryPoint ep : entryPoints) {
+            if (ep.getDirection() == direction) return ep;
+        }
+        return null;
+    }
 
     @Nullable
     public File getSchematicFile(@NotNull File baseDataFolder, @NotNull String schematicSubDir) {
-        Objects.requireNonNull(baseDataFolder, "Base data folder cannot be null");
-        Objects.requireNonNull(schematicSubDir, "Schematic subdirectory cannot be null");
-        if (!baseDataFolder.isDirectory()) {
-            return null;
-        }
-        File schematicsDir = new File(baseDataFolder, schematicSubDir);
-        return new File(schematicsDir, this.schematicFileName);
+        Objects.requireNonNull(baseDataFolder);
+        Objects.requireNonNull(schematicSubDir);
+        if (!baseDataFolder.isDirectory()) return null;
+        return new File(new File(baseDataFolder, schematicSubDir), schematicFileName);
     }
 
     @Override
     public String toString() {
-        // Updated toString to remove deleted fields
-        return "Segment{" +
-                "name='" + name + '\'' +
-                ", type=" + type + // Type is now primary descriptor
-                ", schematic='" + schematicFileName + '\'' +
-                ", size=" + size +
-                ", entryPoints=" + entryPoints.size() +
-                ", vault=" + containedVault + (vaultLocationOffset != null ? "@" + vaultLocationOffset : "") +
-                ", key=" + containedVaultKey + (keyLocationOffset != null ? "@" + keyLocationOffset : "") +
-                '}';
+        return "Segment{name='" + name + "', type=" + type
+                + ", vault=" + containedVault + ", key=" + containedVaultKey
+                + ", gates=" + gates.size() + '}';
     }
 
-    // --- Inner Class: RelativeEntryPoint ---
-    // (Remains the same)
+    // -------------------------------------------------------------------------
+    // Inner class: RelativeEntryPoint
+    // -------------------------------------------------------------------------
+
     public static class RelativeEntryPoint {
         private final BlockVector3 relativePosition;
         private final Direction direction;
 
         public RelativeEntryPoint(@NotNull BlockVector3 relativePosition, @NotNull Direction direction) {
-            this.relativePosition = Objects.requireNonNull(relativePosition, "Relative position cannot be null");
-            this.direction = Objects.requireNonNull(direction, "Direction cannot be null");
+            this.relativePosition = Objects.requireNonNull(relativePosition);
+            this.direction        = Objects.requireNonNull(direction);
         }
 
         @NotNull public BlockVector3 getRelativePosition() { return relativePosition; }
-        @NotNull public Direction getDirection() { return direction; }
-        @NotNull public Direction getOppositeDirection() { return direction.getOpposite(); }
-
-        // These conversion methods likely belong elsewhere or need world context
-        // public com.sk89q.worldedit.util.Location toWorldEditLocation(@NotNull com.sk89q.worldedit.util.Location segmentOriginInWorld) { return null;}
-        // public org.bukkit.Location toBukkitLocation(@NotNull org.bukkit.Location segmentOriginInWorld) { return null;}
+        @NotNull public Direction getDirection()            { return direction; }
+        @NotNull public Direction getOppositeDirection()    { return direction.getOpposite(); }
 
         @Override
         public String toString() {
-            return "RelativeEntryPoint{" +
-                    "relativePosition=" + relativePosition +
-                    ", direction=" + direction +
-                    '}';
+            return "RelativeEntryPoint{pos=" + relativePosition + ", dir=" + direction + '}';
         }
 
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (!(o instanceof RelativeEntryPoint)) return false;
             RelativeEntryPoint that = (RelativeEntryPoint) o;
             return Objects.equals(relativePosition, that.relativePosition) && direction == that.direction;
         }

--- a/src/main/java/com/clarkson/sot/dungeon/segment/SegmentBound.java
+++ b/src/main/java/com/clarkson/sot/dungeon/segment/SegmentBound.java
@@ -1,0 +1,44 @@
+package com.clarkson.sot.dungeon.segment;
+
+import com.sk89q.worldedit.math.BlockVector3;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a 2D rectangular bound (e.g. vault door opening, gate opening) stored
+ * as relative offsets from the segment origin. Both corners are inclusive.
+ */
+public class SegmentBound {
+
+    private final BlockVector3 min;
+    private final BlockVector3 max;
+
+    /**
+     * Constructs a SegmentBound from two corners. Min/max are automatically derived.
+     *
+     * @param corner1 First corner (relative to segment origin).
+     * @param corner2 Second corner (relative to segment origin).
+     */
+    public SegmentBound(@NotNull BlockVector3 corner1, @NotNull BlockVector3 corner2) {
+        this.min = BlockVector3.at(
+            Math.min(corner1.x(), corner2.x()),
+            Math.min(corner1.y(), corner2.y()),
+            Math.min(corner1.z(), corner2.z())
+        );
+        this.max = BlockVector3.at(
+            Math.max(corner1.x(), corner2.x()),
+            Math.max(corner1.y(), corner2.y()),
+            Math.max(corner1.z(), corner2.z())
+        );
+    }
+
+    @NotNull
+    public BlockVector3 getMin() { return min; }
+
+    @NotNull
+    public BlockVector3 getMax() { return max; }
+
+    @Override
+    public String toString() {
+        return "SegmentBound{min=" + min + ", max=" + max + "}";
+    }
+}

--- a/src/main/java/com/clarkson/sot/dungeon/segment/SegmentType.java
+++ b/src/main/java/com/clarkson/sot/dungeon/segment/SegmentType.java
@@ -1,5 +1,19 @@
 package com.clarkson.sot.dungeon.segment;
 
+/**
+ * Categories for segment templates.
+ * Note: The gold key room is identified by {@code containedVaultKey == VaultColor.GOLD},
+ * not by a separate LAVA_PARKOUR type — the builder labels it as whatever room type fits
+ * (typically a challenge room variant).
+ */
 public enum SegmentType {
-    SMALL_ROOM, LARGE_ROOM, CORRIDOR, VAULT, STAIRS, START, PUZZLE, END, LAVA_PARKOUR, HUB
+    HUB,
+    CORRIDOR,
+    SMALL_ROOM,
+    LARGE_ROOM,
+    VAULT,
+    STAIRS,
+    PUZZLE,
+    START,
+    END
 }

--- a/src/main/java/com/clarkson/sot/events/BuilderMode.java
+++ b/src/main/java/com/clarkson/sot/events/BuilderMode.java
@@ -1,0 +1,58 @@
+package com.clarkson.sot.events;
+
+/**
+ * All modes the segment builder tool can operate in.
+ * Point modes place a single marker on right-click.
+ * Bound modes require two right-clicks (first corner, then second corner).
+ */
+public enum BuilderMode {
+
+    ENTRY_POINT("Entry Point",
+            "Right-click a wall face to place. Click existing anchor to rotate.",
+            false),
+    VAULT_DOOR("Vault Door",
+            "Click two air blocks to define the vault door opening. Requires /sotmode VAULT_DOOR <color>.",
+            true),
+    VAULT_MARKER("Vault Marker",
+            "Right-click to mark the vault activation block. Requires /sotmode VAULT_MARKER <color>.",
+            false),
+    KEY_SPAWN("Key Spawn",
+            "Right-click to mark where the key item spawns. Requires /sotmode KEY_SPAWN <color>.",
+            false),
+    GATE("Gate",
+            "Click two air blocks to define the gate opening.",
+            true),
+    LEVER("Lever",
+            "Right-click to mark the lever that opens all gates in this segment.",
+            false),
+    SAND_SPAWN("Sand Spawn",
+            "Right-click to mark a sand spawn position.",
+            false),
+    SAND_SACRIFICE("Sand Sacrifice",
+            "Right-click to mark a sand sacrifice block position.",
+            false),
+    COIN_SPAWN("Coin Spawn",
+            "Right-click to mark a coin spawn. Use /sotmode COIN_SPAWN <value> to set value.",
+            false),
+    ITEM_SPAWN("Item Spawn",
+            "Right-click to mark an item spawn position.",
+            false),
+    MOB_SPAWNER("Mob Spawner",
+            "Right-click to mark a mob spawner position.",
+            false);
+
+    private final String displayName;
+    private final String hint;
+    /** True if this mode uses a two-click bound selection. */
+    private final boolean isBoundMode;
+
+    BuilderMode(String displayName, String hint, boolean isBoundMode) {
+        this.displayName = displayName;
+        this.hint = hint;
+        this.isBoundMode = isBoundMode;
+    }
+
+    public String getDisplayName() { return displayName; }
+    public String getHint() { return hint; }
+    public boolean isBoundMode() { return isBoundMode; }
+}

--- a/src/main/java/com/clarkson/sot/events/BuilderSessionManager.java
+++ b/src/main/java/com/clarkson/sot/events/BuilderSessionManager.java
@@ -1,0 +1,32 @@
+package com.clarkson.sot.events;
+
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Maintains a PlayerBuilderSession for each builder currently using the segment tool.
+ * Sessions are created lazily when first accessed and persist until the server restarts.
+ */
+public class BuilderSessionManager {
+
+    private final Map<UUID, PlayerBuilderSession> sessions = new HashMap<>();
+
+    /**
+     * Gets the session for the given player, creating a new one if it doesn't exist.
+     */
+    @NotNull
+    public PlayerBuilderSession getSession(@NotNull Player player) {
+        return sessions.computeIfAbsent(player.getUniqueId(), uuid -> new PlayerBuilderSession());
+    }
+
+    /**
+     * Removes the session for the given player (e.g. on disconnect).
+     */
+    public void removeSession(@NotNull Player player) {
+        sessions.remove(player.getUniqueId());
+    }
+}

--- a/src/main/java/com/clarkson/sot/events/PlayerBuilderSession.java
+++ b/src/main/java/com/clarkson/sot/events/PlayerBuilderSession.java
@@ -1,0 +1,56 @@
+package com.clarkson.sot.events;
+
+import com.clarkson.sot.dungeon.VaultColor;
+import org.bukkit.Location;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Stores per-player state for the segment builder tool.
+ * One instance is held per online builder in BuilderSessionManager.
+ */
+public class PlayerBuilderSession {
+
+    private BuilderMode mode = BuilderMode.ENTRY_POINT;
+
+    // For modes that require a vault color (VAULT_DOOR, VAULT_MARKER, KEY_SPAWN).
+    @Nullable private VaultColor vaultColor = null;
+
+    // Base coin value used when placing COIN_SPAWN markers.
+    private int coinValue = 10;
+
+    // --- Two-click bound selection state (VAULT_DOOR / GATE) ---
+    /** Absolute world location of the first corner click (air block in front of face). */
+    @Nullable private Location pendingBoundCorner = null;
+    /** UUID of the temporary "first corner" marker entity, so it can be removed on cancel/complete. */
+    @Nullable private UUID pendingCornerEntityId = null;
+
+    // --- Getters and setters ---
+
+    public BuilderMode getMode() { return mode; }
+
+    public void setMode(BuilderMode mode) { this.mode = mode; }
+
+    @Nullable public VaultColor getVaultColor() { return vaultColor; }
+
+    public void setVaultColor(@Nullable VaultColor vaultColor) { this.vaultColor = vaultColor; }
+
+    public int getCoinValue() { return coinValue; }
+
+    public void setCoinValue(int coinValue) { this.coinValue = Math.max(1, coinValue); }
+
+    @Nullable public Location getPendingBoundCorner() { return pendingBoundCorner; }
+
+    public void setPendingBoundCorner(@Nullable Location loc) { this.pendingBoundCorner = loc; }
+
+    @Nullable public UUID getPendingCornerEntityId() { return pendingCornerEntityId; }
+
+    public void setPendingCornerEntityId(@Nullable UUID id) { this.pendingCornerEntityId = id; }
+
+    /** Clears pending bound selection state without changing mode. */
+    public void clearPendingBound() {
+        this.pendingBoundCorner = null;
+        this.pendingCornerEntityId = null;
+    }
+}

--- a/src/main/java/com/clarkson/sot/events/SegmentBuilderKeys.java
+++ b/src/main/java/com/clarkson/sot/events/SegmentBuilderKeys.java
@@ -1,0 +1,36 @@
+package com.clarkson.sot.events;
+
+/**
+ * Centralised PDC key name constants shared between ToolListener and SaveSegmentCommand.
+ * NamespacedKey instances are created per-class using these strings with the plugin instance.
+ */
+public final class SegmentBuilderKeys {
+
+    private SegmentBuilderKeys() {}
+
+    // --- Tool identification ---
+    public static final String TOOL_TYPE        = "sot_tool_type";
+    public static final String TOOL_TYPE_VALUE  = "SEGMENT_BUILDER";
+
+    // --- Marker entity tags ---
+    /** Set to (byte) 1 on every build-phase marker entity. */
+    public static final String BUILD_MARKER_TAG = "sot_build_marker";
+    /** String: the BuilderMode name of this marker (e.g. "ENTRY_POINT", "GATE"). */
+    public static final String MARKER_TYPE      = "sot_marker_type";
+
+    // --- Marker-specific data ---
+    /** String: Direction name stored on entry-point anchor entities. */
+    public static final String DIRECTION        = "sot_direction";
+    /** String: VaultColor name stored on vault door, vault marker, key spawn entities. */
+    public static final String VAULT_COLOR      = "sot_vault_color";
+    /** Integer: base coin value stored on coin-spawn marker entities. */
+    public static final String COIN_VALUE       = "sot_coin_value";
+
+    // --- Bound group (vault door / gate frames) ---
+    /** String UUID: groups anchor + all frame entities for the same bound. */
+    public static final String BOUND_GROUP      = "sot_bound_group";
+    /** String "x,y,z": absolute world min corner stored on the bound anchor entity. */
+    public static final String BOUND_MIN        = "sot_bound_min";
+    /** String "x,y,z": absolute world max corner stored on the bound anchor entity. */
+    public static final String BOUND_MAX        = "sot_bound_max";
+}

--- a/src/main/java/com/clarkson/sot/events/ToolListener.java
+++ b/src/main/java/com/clarkson/sot/events/ToolListener.java
@@ -1,10 +1,9 @@
 package com.clarkson.sot.events;
 
-// Use consistent key definitions - ideally move these to a shared Constants class
+import com.clarkson.sot.dungeon.VaultColor;
+import com.clarkson.sot.dungeon.segment.Direction;
 import com.clarkson.sot.main.SoT;
-import com.clarkson.sot.dungeon.segment.Direction; // Import Direction
 
-// Adventure API Imports
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
@@ -13,10 +12,10 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.BlockDisplay;
 import org.bukkit.entity.Display;
-import org.bukkit.entity.Entity; // Import base Entity class
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.ItemDisplay;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -28,367 +27,631 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.util.RayTraceResult; // Import for entity ray tracing
+import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Transformation;
 import org.joml.AxisAngle4f;
-import org.joml.Quaternionf; // Using Quaternion for potentially easier rotation
+import org.joml.Quaternionf;
 import org.joml.Vector3f;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Predicate;
 import java.util.logging.Level;
-import java.util.function.Predicate; // For ray trace filter
 
 /**
- * Listens for interactions with SoT tools.
- * Right-click places markers OR rotates existing entry point markers.
- * Left-click removes markers the player is looking at.
+ * Handles interactions with the master segment builder tool (BLAZE_ROD tagged as SEGMENT_BUILDER).
+ * <p>
+ * Right-click: places a marker in the current mode.
+ * Left-click:  removes the marker being looked at.
+ * <p>
+ * All markers are BlockDisplay entities tagged with BUILD_MARKER_TAG so they can be
+ * found by SaveSegmentCommand and removed by left-click.
  */
 public class ToolListener implements Listener {
 
     private final SoT plugin;
+    private final BuilderSessionManager sessionManager;
 
-    // --- Constants ---
-    private static final int COIN_STACK_SMALL_MODEL_ID = 1001;
-    private static final int COIN_STACK_MEDIUM_MODEL_ID = 1002;
-    private static final int COIN_STACK_LARGE_MODEL_ID = 1003;
-    private static final Material COIN_BASE_MATERIAL = Material.GOLD_NUGGET;
-    private static final Material ITEM_SPAWN_MARKER_ITEM_MATERIAL = Material.TORCH;
-    private static final Material ENTRY_POINT_MARKER_ITEM_MATERIAL = Material.ARROW; // Item to display for entry points
-
-    // --- PDC Keys (Define consistently) ---
+    // --- PDC keys ---
     private final NamespacedKey TOOL_TYPE_KEY;
-    private final NamespacedKey TOOL_VALUE_KEY; // Used by coin tool
-    private final NamespacedKey MARKER_TYPE_KEY; // Used for the marker entity (ItemDisplay or ArmorStand)
-    private final NamespacedKey DIRECTION_KEY; // Used for entry point marker entity
-    private final NamespacedKey VAULT_COLOR_KEY; // Used for vault/key marker entity
-    private final NamespacedKey BUILD_MARKER_TAG; // Tag identifying ANY build-phase marker entity
+    private final NamespacedKey BUILD_MARKER_TAG;
+    private final NamespacedKey MARKER_TYPE_KEY;
+    private final NamespacedKey DIRECTION_KEY;
+    private final NamespacedKey VAULT_COLOR_KEY;
+    private final NamespacedKey COIN_VALUE_KEY;
+    private final NamespacedKey BOUND_GROUP_KEY;
+    private final NamespacedKey BOUND_MIN_KEY;
+    private final NamespacedKey BOUND_MAX_KEY;
 
-    public ToolListener(SoT plugin) {
+    // Marker type string constants
+    private static final String MT_ENTRY_POINT      = "ENTRY_POINT";
+    private static final String MT_ENTRY_FRAME      = "ENTRY_FRAME";
+    private static final String MT_VAULT_DOOR       = "VAULT_DOOR";
+    private static final String MT_VAULT_MARKER     = "VAULT_MARKER";
+    private static final String MT_KEY_SPAWN        = "KEY_SPAWN";
+    private static final String MT_GATE             = "GATE";
+    private static final String MT_BOUND_FRAME      = "BOUND_FRAME";
+    private static final String MT_BOUND_CORNER1    = "BOUND_CORNER1";
+    private static final String MT_LEVER            = "LEVER";
+    private static final String MT_SAND_SPAWN       = "SAND_SPAWN";
+    private static final String MT_SAND_SACRIFICE   = "SAND_SACRIFICE";
+    private static final String MT_COIN_SPAWN       = "COIN_SPAWN";
+    private static final String MT_ITEM_SPAWN       = "ITEM_SPAWN";
+    private static final String MT_MOB_SPAWNER      = "MOB_SPAWNER";
+
+    // Entry point frame: 2 wide x 3 tall (all 6 positions are border)
+    private static final int EP_WIDTH  = 2;
+    private static final int EP_HEIGHT = 3;
+
+    public ToolListener(@NotNull SoT plugin, @NotNull BuilderSessionManager sessionManager) {
         this.plugin = plugin;
-        // Initialize keys
-        TOOL_TYPE_KEY = new NamespacedKey(plugin, "sot_tool_type");
-        TOOL_VALUE_KEY = new NamespacedKey(plugin, "sot_tool_value");
-        MARKER_TYPE_KEY = new NamespacedKey(plugin, "sot_marker_type");
-        DIRECTION_KEY = new NamespacedKey(plugin, "sot_direction");
-        VAULT_COLOR_KEY = new NamespacedKey(plugin, "sot_vault_color");
-        BUILD_MARKER_TAG = new NamespacedKey(plugin, "sot_build_marker"); // Key for the general build marker tag
+        this.sessionManager = sessionManager;
+        TOOL_TYPE_KEY   = new NamespacedKey(plugin, SegmentBuilderKeys.TOOL_TYPE);
+        BUILD_MARKER_TAG= new NamespacedKey(plugin, SegmentBuilderKeys.BUILD_MARKER_TAG);
+        MARKER_TYPE_KEY = new NamespacedKey(plugin, SegmentBuilderKeys.MARKER_TYPE);
+        DIRECTION_KEY   = new NamespacedKey(plugin, SegmentBuilderKeys.DIRECTION);
+        VAULT_COLOR_KEY = new NamespacedKey(plugin, SegmentBuilderKeys.VAULT_COLOR);
+        COIN_VALUE_KEY  = new NamespacedKey(plugin, SegmentBuilderKeys.COIN_VALUE);
+        BOUND_GROUP_KEY = new NamespacedKey(plugin, SegmentBuilderKeys.BOUND_GROUP);
+        BOUND_MIN_KEY   = new NamespacedKey(plugin, SegmentBuilderKeys.BOUND_MIN);
+        BOUND_MAX_KEY   = new NamespacedKey(plugin, SegmentBuilderKeys.BOUND_MAX);
     }
+
+    // -------------------------------------------------------------------------
+    // Main event handler
+    // -------------------------------------------------------------------------
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onPlayerInteract(PlayerInteractEvent event) {
-        if (event.getHand() != EquipmentSlot.HAND) return; // Only handle main hand
+        if (event.getHand() != EquipmentSlot.HAND) return;
 
         Player player = event.getPlayer();
-        ItemStack itemInHand = event.getItem();
-
-        if (itemInHand == null || itemInHand.getType() == Material.AIR) return;
-        ItemMeta meta = itemInHand.getItemMeta();
+        ItemStack item = event.getItem();
+        if (item == null || item.getType() == Material.AIR) return;
+        ItemMeta meta = item.getItemMeta();
         if (meta == null) return;
-        PersistentDataContainer pdc = meta.getPersistentDataContainer();
-        if (!pdc.has(TOOL_TYPE_KEY, PersistentDataType.STRING)) return; // Not one of our tools
 
-        String toolType = pdc.get(TOOL_TYPE_KEY, PersistentDataType.STRING);
+        String toolType = meta.getPersistentDataContainer()
+                .get(TOOL_TYPE_KEY, PersistentDataType.STRING);
+        if (!SegmentBuilderKeys.TOOL_TYPE_VALUE.equals(toolType)) return;
 
-        // --- Handle Right-Click (Placement or Rotation) ---
-        if (event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
-            if ("COIN_PLACER".equals(toolType)) {
-                handleCoinPlacerTool(event, player, pdc);
-            } else if ("ITEM_SPAWN_PLACER".equals(toolType)) {
-                handleItemSpawnPlacerTool(event, player);
-            } else if ("ENTRY_POINT_PLACER".equals(toolType)) {
-                handleEntryPointPlacerTool(event, player); // Doesn't need tool PDC anymore
-            }
-            // Add other right-click tool handlers here
+        if (!player.hasPermission("sot.admin.builder")) {
+            player.sendActionBar(Component.text("No permission.", NamedTextColor.RED));
+            event.setCancelled(true);
+            return;
         }
-        // --- Handle Left-Click (Removal) ---
-        else if (event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK) {
-            // Check if the tool held is *any* of our placement tools
-            if ("COIN_PLACER".equals(toolType) || "ITEM_SPAWN_PLACER".equals(toolType) || "ENTRY_POINT_PLACER".equals(toolType)) {
-                 handleMarkerRemoval(event, player);
-            }
-        }
-    }
 
-    // --- Tool Handlers ---
-
-    private void handleCoinPlacerTool(PlayerInteractEvent event, Player player, PersistentDataContainer toolPdc) {
         event.setCancelled(true);
-        if (!player.hasPermission("sot.admin.placedisplay")) { /* ... perm msg ... */ return; }
-        if (!toolPdc.has(TOOL_VALUE_KEY, PersistentDataType.INTEGER)) { /* ... missing value msg ... */ return; }
-        int baseValue = toolPdc.get(TOOL_VALUE_KEY, PersistentDataType.INTEGER);
-        spawnCoinDisplayVisual(player, baseValue, event.getClickedBlock(), event.getBlockFace());
-    }
 
-    private void handleItemSpawnPlacerTool(PlayerInteractEvent event, Player player) {
-        event.setCancelled(true);
-        if (!player.hasPermission("sot.admin.placeitemspawn")) { /* ... perm msg ... */ return; }
-        // Require clicking the top face of a block
-        if (event.getAction() != Action.RIGHT_CLICK_BLOCK || event.getClickedBlock() == null || event.getBlockFace() != BlockFace.UP) {
-             player.sendActionBar(Component.text("Right-click on the top face of a block to place marker.", NamedTextColor.YELLOW));
-             return;
-        }
-        placeItemSpawnMarker(player, event.getClickedBlock(), event.getBlockFace());
-    }
-
-    private void handleEntryPointPlacerTool(PlayerInteractEvent event, Player player) {
-        event.setCancelled(true); // Cancel event regardless of outcome below
-        if (!player.hasPermission("sot.admin.placeentrypoint")) {
-             player.sendMessage(Component.text("You don't have permission to use this tool.", NamedTextColor.RED));
-             return;
-        }
-
-        // 1. Check if player is looking at an existing Entry Point marker entity
-        double range = 5.0; // Range to check for existing markers
-        Predicate<Entity> filter = entity -> entity instanceof ItemDisplay // Check type
-                && entity.getPersistentDataContainer().has(BUILD_MARKER_TAG, PersistentDataType.BYTE) // Check general marker tag
-                && "ENTRYPOINT".equals(entity.getPersistentDataContainer().get(MARKER_TYPE_KEY, PersistentDataType.STRING)); // Check specific type
-
-        RayTraceResult result = player.getWorld().rayTraceEntities(player.getEyeLocation(), player.getEyeLocation().getDirection(), range, filter);
-
-        if (result != null && result.getHitEntity() != null && result.getHitEntity() instanceof ItemDisplay) {
-            // Player is looking at an existing entry point marker -> ROTATE IT
-            rotateEntryPointMarker(player, (ItemDisplay) result.getHitEntity());
-        }
-        // 2. If not looking at a marker, check if they right-clicked a block -> PLACE NEW
-        else if (event.getAction() == Action.RIGHT_CLICK_BLOCK && event.getClickedBlock() != null && event.getBlockFace() != null) {
-            // Place a new marker, default direction based on player facing away from block face
-            Direction defaultDirection = Direction.fromBlockFace(event.getBlockFace().getOppositeFace()); // Get direction pointing OUT from block
-             if(defaultDirection == Direction.UP || defaultDirection == Direction.DOWN) {
-                 // If clicked top/bottom, default to player's horizontal facing
-                 defaultDirection = Direction.fromYaw(player.getLocation().getYaw());
-             }
-            placeEntryPointMarker(player, event.getClickedBlock(), event.getBlockFace(), defaultDirection);
-        }
-        // 3. If right-clicked air and not looking at marker -> do nothing or give feedback
-        else if (event.getAction() == Action.RIGHT_CLICK_AIR) {
-             player.sendActionBar(Component.text("Right-click a block face to place, or an existing marker to rotate.", NamedTextColor.YELLOW));
+        Action action = event.getAction();
+        if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK) {
+            handleRightClick(event, player);
+        } else if (action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK) {
+            handleLeftClick(player);
         }
     }
 
+    // -------------------------------------------------------------------------
+    // Right-click dispatch
+    // -------------------------------------------------------------------------
 
-    /** Handles logic for removing markers (Left-Click) */
-    private void handleMarkerRemoval(PlayerInteractEvent event, Player player) {
-        event.setCancelled(true);
-        if (!player.hasPermission("sot.admin.removemarker")) {
-             player.sendActionBar(Component.text("You don't have permission to remove markers.", NamedTextColor.RED));
-             return;
-        }
-        double range = 6.0;
-        Predicate<Entity> filter = entity -> (entity instanceof ItemDisplay) // Only check ItemDisplays now if ArmorStands aren't used
-                   && entity.getPersistentDataContainer().has(BUILD_MARKER_TAG, PersistentDataType.BYTE);
+    private void handleRightClick(PlayerInteractEvent event, Player player) {
+        PlayerBuilderSession session = sessionManager.getSession(player);
+        BuilderMode mode = session.getMode();
 
-        RayTraceResult result = player.getWorld().rayTraceEntities(player.getEyeLocation(), player.getEyeLocation().getDirection(), range, filter);
-
-        if (result != null && result.getHitEntity() != null) {
-            Entity hitEntity = result.getHitEntity();
-            // No need to double-check tag if filter is reliable
-            String markerType = hitEntity.getPersistentDataContainer().getOrDefault(MARKER_TYPE_KEY, PersistentDataType.STRING, "Unknown");
-            hitEntity.remove();
-            player.sendActionBar(Component.text("Removed " + markerType + " marker.", NamedTextColor.YELLOW));
-        } else {
-            player.sendActionBar(Component.text("No marker found in sight.", NamedTextColor.GRAY));
-        }
-    }
-
-
-    // --- Spawning and Rotating Methods ---
-
-    /** Spawns the visual ItemDisplay for a coin stack. */
-    private void spawnCoinDisplayVisual(Player player, int baseValue, Block clickedBlock, BlockFace clickedFace) {
-        int modelIdToUse;
-        if (baseValue >= 50) modelIdToUse = COIN_STACK_LARGE_MODEL_ID;
-        else if (baseValue >= 20) modelIdToUse = COIN_STACK_MEDIUM_MODEL_ID;
-        else modelIdToUse = COIN_STACK_SMALL_MODEL_ID;
-
-        ItemStack displayStack = new ItemStack(COIN_BASE_MATERIAL);
-        ItemMeta meta = displayStack.getItemMeta();
-        if (meta != null) { meta.setCustomModelData(modelIdToUse); displayStack.setItemMeta(meta); }
-        else { player.sendMessage(Component.text("Error: Could not get ItemMeta for Coin Display.", NamedTextColor.RED)); return; }
-
-        Location spawnLocation = calculatePlacementLocation(player, clickedBlock, clickedFace, 0.1);
-
-        try {
-            player.getWorld().spawn(spawnLocation, ItemDisplay.class, display -> {
-                display.setItemStack(displayStack);
-                display.setGravity(false); display.setInvulnerable(true); display.setBillboard(Display.Billboard.CENTER);
-                float scale = 1.5f;
-                Transformation transformation = new Transformation( new Vector3f(0f, 0f, 0f), new AxisAngle4f(0f, 0f, 0f, 1f), new Vector3f(scale, scale, scale), new AxisAngle4f(0f, 0f, 0f, 1f) );
-                display.setTransformation(transformation);
-                PersistentDataContainer pdc = display.getPersistentDataContainer();
-                pdc.set(BUILD_MARKER_TAG, PersistentDataType.BYTE, (byte)1);
-                pdc.set(MARKER_TYPE_KEY, PersistentDataType.STRING, "DISPLAY_COIN"); // Add type for removal message
-            });
-            player.sendActionBar(Component.text("Placed Coin Display (Value: " + baseValue + ")", NamedTextColor.GREEN));
-        } catch (Exception e) {
-             plugin.getLogger().log(Level.SEVERE, "Failed to spawn Coin ItemDisplay via tool", e);
-             player.sendMessage(Component.text("An error occurred while spawning the coin display entity.", NamedTextColor.RED));
+        switch (mode) {
+            case ENTRY_POINT:
+                handleEntryPoint(event, player);
+                break;
+            case VAULT_DOOR:
+            case GATE:
+                handleBoundFirstOrSecondClick(event, player, session, mode);
+                break;
+            case VAULT_MARKER:
+                placePointMarker(event, player, MT_VAULT_MARKER,
+                        Material.PURPLE_WOOL, 0.5f, session.getVaultColor(), -1);
+                break;
+            case KEY_SPAWN:
+                placePointMarker(event, player, MT_KEY_SPAWN,
+                        Material.YELLOW_WOOL, 0.5f, session.getVaultColor(), -1);
+                break;
+            case LEVER:
+                placePointMarker(event, player, MT_LEVER,
+                        Material.LEVER, 0.5f, null, -1);
+                break;
+            case SAND_SPAWN:
+                placePointMarker(event, player, MT_SAND_SPAWN,
+                        Material.SAND, 0.5f, null, -1);
+                break;
+            case SAND_SACRIFICE:
+                placePointMarker(event, player, MT_SAND_SACRIFICE,
+                        Material.GOLD_BLOCK, 0.5f, null, -1);
+                break;
+            case COIN_SPAWN:
+                placePointMarker(event, player, MT_COIN_SPAWN,
+                        Material.YELLOW_CONCRETE, 0.4f, null, session.getCoinValue());
+                break;
+            case ITEM_SPAWN:
+                placePointMarker(event, player, MT_ITEM_SPAWN,
+                        Material.BARREL, 0.5f, null, -1);
+                break;
+            case MOB_SPAWNER:
+                placePointMarker(event, player, MT_MOB_SPAWNER,
+                        Material.SPAWNER, 0.5f, null, -1);
+                break;
         }
     }
 
-    /** Places an ItemDisplay showing a flat torch item, tagged as an item spawn marker. */
-    private void placeItemSpawnMarker(Player player, Block clickedBlock, BlockFace clickedFace) {
-         Block blockToPlaceOn = clickedBlock; // Clicked on top face, place marker above
-         Block targetBlock = blockToPlaceOn.getRelative(BlockFace.UP); // Target air block above
-         Location spawnLocation = targetBlock.getLocation().add(0.5, 0.0, 0.5); // Center of the block space, Y aligned with base
+    // -------------------------------------------------------------------------
+    // Entry point handler (right-click places or rotates)
+    // -------------------------------------------------------------------------
 
-         if (!targetBlock.getType().isAir() && targetBlock.getType() != Material.CAVE_AIR && targetBlock.getType() != Material.VOID_AIR) {
-              player.sendActionBar(Component.text("Cannot place marker here (space occupied).", NamedTextColor.RED));
-              return;
-         }
+    private void handleEntryPoint(PlayerInteractEvent event, Player player) {
+        // First check: is the player looking at an existing entry-point anchor? -> rotate
+        Predicate<Entity> anchorFilter = e ->
+                e instanceof BlockDisplay
+                && e.getPersistentDataContainer().has(BUILD_MARKER_TAG, PersistentDataType.BYTE)
+                && MT_ENTRY_POINT.equals(e.getPersistentDataContainer()
+                        .get(MARKER_TYPE_KEY, PersistentDataType.STRING));
 
-         try {
-             ItemStack torchItem = new ItemStack(ITEM_SPAWN_MARKER_ITEM_MATERIAL);
-             player.getWorld().spawn(spawnLocation, ItemDisplay.class, display -> {
-                 display.setItemStack(torchItem);
-                 display.setGravity(false); display.setInvulnerable(true); display.setPersistent(true); display.setBillboard(Display.Billboard.FIXED);
-                 float scale = 0.7f;
-                 AxisAngle4f rotation = new AxisAngle4f((float) Math.toRadians(90), 1f, 0f, 0f); // Lay flat on X axis
-                 Vector3f translation = new Vector3f(0f, -0.4f, 0f); // Lower slightly
-                 Transformation transformation = new Transformation( translation, rotation, new Vector3f(scale, scale, scale), new AxisAngle4f(0f, 0f, 0f, 1f) );
-                 display.setTransformation(transformation);
-                 PersistentDataContainer pdc = display.getPersistentDataContainer();
-                 pdc.set(MARKER_TYPE_KEY, PersistentDataType.STRING, "SPAWN_ITEM");
-                 pdc.set(BUILD_MARKER_TAG, PersistentDataType.BYTE, (byte)1);
-             });
-              player.sendActionBar(Component.text("Placed Item Spawn Marker (Torch Item).", NamedTextColor.GREEN));
-         } catch (Exception e) {
-             plugin.getLogger().log(Level.SEVERE, "Failed to spawn marker ItemDisplay for item spawn", e);
-             player.sendMessage(Component.text("Error placing marker entity.", NamedTextColor.RED));
-         }
+        RayTraceResult ray = player.getWorld().rayTraceEntities(
+                player.getEyeLocation(), player.getEyeLocation().getDirection(), 6.0, anchorFilter);
+
+        if (ray != null && ray.getHitEntity() instanceof BlockDisplay) {
+            rotateEntryPointFrame((BlockDisplay) ray.getHitEntity(), player);
+            return;
+        }
+
+        // Otherwise: right-clicked a block face -> place new entry point frame
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK
+                || event.getClickedBlock() == null
+                || event.getBlockFace() == null) {
+            player.sendActionBar(Component.text(
+                    "Right-click a wall face to place, or an existing entry point to rotate.",
+                    NamedTextColor.YELLOW));
+            return;
+        }
+
+        Block clicked = event.getClickedBlock();
+        BlockFace face = event.getBlockFace();
+
+        // Air block in front of the clicked face = bottom-left corner of the opening
+        Block airBlock = clicked.getRelative(face);
+        if (!airBlock.getType().isAir()) {
+            player.sendActionBar(Component.text(
+                    "No air space in front of that face.", NamedTextColor.RED));
+            return;
+        }
+
+        Direction dir = Direction.fromBlockFace(face);
+        if (dir == Direction.UP || dir == Direction.DOWN) {
+            dir = Direction.fromYaw(player.getLocation().getYaw());
+        }
+
+        spawnEntryPointFrame(player, airBlock.getLocation(), dir);
     }
 
     /**
-     * Places a new ItemDisplay showing an arrow pointing in the specified direction,
-     * tagged as an entry point marker.
-     * @param player Player using the tool.
-     * @param clickedBlock The block clicked.
-     * @param clickedFace The face of the block clicked.
-     * @param directionToPlace The initial direction the entry point should face.
+     * Spawns a 2x3 frame of LIME_STAINED_GLASS BlockDisplays at the given bottom-left anchor location.
+     * One entity is tagged as the ENTRY_POINT anchor; the rest as ENTRY_FRAME. All share a group ID.
      */
-    private void placeEntryPointMarker(Player player, Block clickedBlock, BlockFace clickedFace, Direction directionToPlace) {
-        Block targetBlock = clickedBlock.getRelative(clickedFace);
-        Location spawnLocation = targetBlock.getLocation().add(0.5, 0.5, 0.5); // Center of the target block
+    private void spawnEntryPointFrame(Player player, Location anchorBlockLoc, Direction dir) {
+        String groupId = UUID.randomUUID().toString();
+        BlockData glass = Material.LIME_STAINED_GLASS.createBlockData();
 
-        if (!targetBlock.getType().isAir() && targetBlock.getType() != Material.CAVE_AIR && targetBlock.getType() != Material.VOID_AIR) {
-             player.sendActionBar(Component.text("Cannot place entry marker here (space occupied).", NamedTextColor.RED));
-             return;
+        // Calculate frame offsets based on facing direction.
+        // "anchor" is the bottom-left block of the opening from the outside perspective.
+        List<int[]> offsets = getEntryPointOffsets(dir); // list of [dx, dy, dz]
+
+        boolean firstEntity = true;
+        UUID anchorEntityId = null;
+
+        for (int[] off : offsets) {
+            Location spawnLoc = anchorBlockLoc.clone().add(off[0], off[1], off[2]);
+            // Spawn at block center
+            Location entityLoc = spawnLoc.clone().add(0.5, 0.0, 0.5);
+
+            int[] capturedOff = off;
+            boolean isAnchor = firstEntity;
+            try {
+                BlockDisplay bd = player.getWorld().spawn(entityLoc, BlockDisplay.class, display -> {
+                    display.setBlock(glass);
+                    display.setGravity(false);
+                    display.setInvulnerable(true);
+                    display.setPersistent(true);
+                    // Scale slightly sub-block to show individual blocks clearly
+                    display.setTransformation(new Transformation(
+                            new Vector3f(0f, 0f, 0f),
+                            new AxisAngle4f(0f, 0f, 0f, 1f),
+                            new Vector3f(0.9f, 0.9f, 0.9f),
+                            new AxisAngle4f(0f, 0f, 0f, 1f)
+                    ));
+                    PersistentDataContainer pdc = display.getPersistentDataContainer();
+                    pdc.set(BUILD_MARKER_TAG, PersistentDataType.BYTE, (byte) 1);
+                    pdc.set(BOUND_GROUP_KEY, PersistentDataType.STRING, groupId);
+                    if (isAnchor) {
+                        pdc.set(MARKER_TYPE_KEY, PersistentDataType.STRING, MT_ENTRY_POINT);
+                        pdc.set(DIRECTION_KEY, PersistentDataType.STRING, dir.name());
+                    } else {
+                        pdc.set(MARKER_TYPE_KEY, PersistentDataType.STRING, MT_ENTRY_FRAME);
+                    }
+                });
+                if (isAnchor) {
+                    anchorEntityId = bd.getUniqueId();
+                }
+            } catch (Exception e) {
+                plugin.getLogger().log(Level.SEVERE, "Failed to spawn entry point frame entity", e);
+            }
+            firstEntity = false;
         }
 
+        player.sendActionBar(Component.text(
+                "Placed Entry Point (" + dir.name() + ")", NamedTextColor.GREEN));
+    }
+
+    /** Rotates an existing entry point frame to the next cardinal direction. */
+    private void rotateEntryPointFrame(BlockDisplay anchor, Player player) {
+        PersistentDataContainer pdc = anchor.getPersistentDataContainer();
+        String dirStr = pdc.get(DIRECTION_KEY, PersistentDataType.STRING);
+        Direction current;
         try {
-            ItemStack arrowItem = new ItemStack(ENTRY_POINT_MARKER_ITEM_MATERIAL);
-            AxisAngle4f rotation = calculateRotationForDirection(directionToPlace); // Use helper
-            float scale = 1.0f;
-            Vector3f translation = new Vector3f(0f, 0f, 0f);
-            Transformation transformation = new Transformation(translation, rotation, new Vector3f(scale, scale, scale), new AxisAngle4f());
+            current = (dirStr != null) ? Direction.valueOf(dirStr) : Direction.NORTH;
+        } catch (IllegalArgumentException e) {
+            current = Direction.NORTH;
+        }
 
-            player.getWorld().spawn(spawnLocation, ItemDisplay.class, display -> {
-                display.setItemStack(arrowItem);
-                display.setGravity(false); display.setInvulnerable(true); display.setPersistent(true); display.setBillboard(Display.Billboard.FIXED);
-                display.setTransformation(transformation); // Apply calculated rotation
+        Direction next;
+        switch (current) {
+            case NORTH: next = Direction.EAST;  break;
+            case EAST:  next = Direction.SOUTH; break;
+            case SOUTH: next = Direction.WEST;  break;
+            default:    next = Direction.NORTH; break;
+        }
 
+        String groupId = pdc.getOrDefault(BOUND_GROUP_KEY, PersistentDataType.STRING, "");
+
+        // Remove all existing frame entities (anchor + frames)
+        Location anchorBlockLoc = anchor.getLocation().clone().subtract(0.5, 0, 0.5);
+        removeGroupEntities(groupId, anchor.getWorld());
+
+        // Respawn frame at the same anchor block location with new direction
+        spawnEntryPointFrame(player, anchorBlockLoc, next);
+    }
+
+    /**
+     * Returns the list of [dx, dy, dz] offsets for a 2-wide x 3-tall entry point frame,
+     * oriented for the given facing direction. The anchor (index 0) is always included.
+     */
+    private List<int[]> getEntryPointOffsets(Direction dir) {
+        List<int[]> offsets = new ArrayList<>();
+        // For NORTH/SOUTH: frame spans X and Y; Z = 0
+        // For EAST/WEST:   frame spans Z and Y; X = 0
+        for (int row = 0; row < EP_HEIGHT; row++) {
+            for (int col = 0; col < EP_WIDTH; col++) {
+                if (dir == Direction.NORTH || dir == Direction.SOUTH) {
+                    offsets.add(new int[]{col, row, 0});
+                } else { // EAST / WEST
+                    offsets.add(new int[]{0, row, col});
+                }
+            }
+        }
+        return offsets;
+    }
+
+    // -------------------------------------------------------------------------
+    // Two-click bound handler (VAULT_DOOR and GATE)
+    // -------------------------------------------------------------------------
+
+    private void handleBoundFirstOrSecondClick(PlayerInteractEvent event, Player player,
+                                               PlayerBuilderSession session, BuilderMode mode) {
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK
+                || event.getClickedBlock() == null
+                || event.getBlockFace() == null) {
+            player.sendActionBar(Component.text(
+                    "Right-click a block face to select a corner.", NamedTextColor.YELLOW));
+            return;
+        }
+
+        // Selection is the air block in front of the clicked face (the actual opening boundary)
+        Block airBlock = event.getClickedBlock().getRelative(event.getBlockFace());
+        if (!airBlock.getType().isAir()) {
+            player.sendActionBar(Component.text(
+                    "Corner must be an air block — click the face bordering the opening.",
+                    NamedTextColor.RED));
+            return;
+        }
+
+        Location corner = airBlock.getLocation();
+
+        if (session.getPendingBoundCorner() == null) {
+            // First corner
+            session.setPendingBoundCorner(corner);
+
+            // Spawn a temp first-corner indicator
+            try {
+                Material mat = (mode == BuilderMode.VAULT_DOOR)
+                        ? Material.PURPLE_STAINED_GLASS : Material.GRAY_STAINED_GLASS;
+                BlockDisplay bd = player.getWorld().spawn(
+                        corner.clone().add(0.5, 0.0, 0.5), BlockDisplay.class, display -> {
+                    display.setBlock(mat.createBlockData());
+                    display.setGravity(false);
+                    display.setInvulnerable(true);
+                    display.setPersistent(true);
+                    display.setTransformation(new Transformation(
+                            new Vector3f(0f, 0f, 0f),
+                            new AxisAngle4f(0f, 0f, 0f, 1f),
+                            new Vector3f(0.9f, 0.9f, 0.9f),
+                            new AxisAngle4f(0f, 0f, 0f, 1f)
+                    ));
+                    PersistentDataContainer pdc = display.getPersistentDataContainer();
+                    pdc.set(BUILD_MARKER_TAG, PersistentDataType.BYTE, (byte) 1);
+                    pdc.set(MARKER_TYPE_KEY, PersistentDataType.STRING, MT_BOUND_CORNER1);
+                });
+                session.setPendingCornerEntityId(bd.getUniqueId());
+            } catch (Exception e) {
+                plugin.getLogger().log(Level.WARNING, "Failed to spawn temp corner entity", e);
+            }
+
+            player.sendActionBar(Component.text(
+                    "First corner set — right-click the opposite corner.", NamedTextColor.YELLOW));
+
+        } else {
+            // Second corner — complete the bound
+            Location corner1 = session.getPendingBoundCorner();
+            Location corner2 = corner;
+
+            // Remove temp first-corner entity
+            if (session.getPendingCornerEntityId() != null) {
+                player.getWorld().getEntities().stream()
+                        .filter(e -> e.getUniqueId().equals(session.getPendingCornerEntityId()))
+                        .forEach(Entity::remove);
+            }
+            session.clearPendingBound();
+
+            // Spawn the perimeter frame
+            String markerType = (mode == BuilderMode.VAULT_DOOR) ? MT_VAULT_DOOR : MT_GATE;
+            Material frameMat = (mode == BuilderMode.VAULT_DOOR)
+                    ? Material.PURPLE_STAINED_GLASS : Material.GRAY_STAINED_GLASS;
+            VaultColor color = (mode == BuilderMode.VAULT_DOOR) ? session.getVaultColor() : null;
+
+            spawnBoundFrame(player, corner1, corner2, markerType, frameMat, color);
+        }
+    }
+
+    /**
+     * Spawns a hollow perimeter of BlockDisplay entities around the 2D rectangle defined
+     * by two corner locations. One entity is the anchor (stores bound data); the rest are frames.
+     */
+    private void spawnBoundFrame(Player player, Location corner1, Location corner2,
+                                 String markerType, Material material,
+                                 @Nullable VaultColor vaultColor) {
+        String groupId = UUID.randomUUID().toString();
+
+        int x1 = corner1.getBlockX(), y1 = corner1.getBlockY(), z1 = corner1.getBlockZ();
+        int x2 = corner2.getBlockX(), y2 = corner2.getBlockY(), z2 = corner2.getBlockZ();
+
+        int minX = Math.min(x1, x2), maxX = Math.max(x1, x2);
+        int minY = Math.min(y1, y2), maxY = Math.max(y1, y2);
+        int minZ = Math.min(z1, z2), maxZ = Math.max(z1, z2);
+
+        // Determine the flat axis (smallest delta → the plane's depth axis)
+        int dx = maxX - minX, dy = maxY - minY, dz = maxZ - minZ;
+
+        List<int[]> perimeterPositions = new ArrayList<>();
+        if (dz <= dx && dz <= dy) {
+            // XY plane (flat in Z)
+            int z = minZ;
+            for (int x = minX; x <= maxX; x++) {
+                perimeterPositions.add(new int[]{x, minY, z});
+                if (minY != maxY) perimeterPositions.add(new int[]{x, maxY, z});
+            }
+            for (int y = minY + 1; y < maxY; y++) {
+                perimeterPositions.add(new int[]{minX, y, z});
+                if (minX != maxX) perimeterPositions.add(new int[]{maxX, y, z});
+            }
+        } else if (dx <= dy && dx <= dz) {
+            // ZY plane (flat in X)
+            int x = minX;
+            for (int z = minZ; z <= maxZ; z++) {
+                perimeterPositions.add(new int[]{x, minY, z});
+                if (minY != maxY) perimeterPositions.add(new int[]{x, maxY, z});
+            }
+            for (int y = minY + 1; y < maxY; y++) {
+                perimeterPositions.add(new int[]{x, y, minZ});
+                if (minZ != maxZ) perimeterPositions.add(new int[]{x, y, maxZ});
+            }
+        } else {
+            // XZ plane (flat in Y)
+            int y = minY;
+            for (int x = minX; x <= maxX; x++) {
+                perimeterPositions.add(new int[]{x, y, minZ});
+                if (minZ != maxZ) perimeterPositions.add(new int[]{x, y, maxZ});
+            }
+            for (int z = minZ + 1; z < maxZ; z++) {
+                perimeterPositions.add(new int[]{minX, y, z});
+                if (minX != maxX) perimeterPositions.add(new int[]{maxX, y, z});
+            }
+        }
+
+        // Store absolute corner strings for SaveSegmentCommand
+        String minStr = minX + "," + minY + "," + minZ;
+        String maxStr = maxX + "," + maxY + "," + maxZ;
+
+        BlockData blockData = material.createBlockData();
+        boolean isFirstEntity = true;
+        final String vaultColorName = (vaultColor != null) ? vaultColor.name() : null;
+
+        for (int[] pos : perimeterPositions) {
+            Location spawnLoc = new Location(player.getWorld(), pos[0] + 0.5, pos[1], pos[2] + 0.5);
+            boolean isAnchor = isFirstEntity;
+            try {
+                player.getWorld().spawn(spawnLoc, BlockDisplay.class, display -> {
+                    display.setBlock(blockData);
+                    display.setGravity(false);
+                    display.setInvulnerable(true);
+                    display.setPersistent(true);
+                    display.setTransformation(new Transformation(
+                            new Vector3f(0f, 0f, 0f),
+                            new AxisAngle4f(0f, 0f, 0f, 1f),
+                            new Vector3f(0.9f, 0.9f, 0.9f),
+                            new AxisAngle4f(0f, 0f, 0f, 1f)
+                    ));
+                    PersistentDataContainer pdc = display.getPersistentDataContainer();
+                    pdc.set(BUILD_MARKER_TAG, PersistentDataType.BYTE, (byte) 1);
+                    pdc.set(BOUND_GROUP_KEY, PersistentDataType.STRING, groupId);
+                    if (isAnchor) {
+                        pdc.set(MARKER_TYPE_KEY, PersistentDataType.STRING, markerType);
+                        pdc.set(BOUND_MIN_KEY, PersistentDataType.STRING, minStr);
+                        pdc.set(BOUND_MAX_KEY, PersistentDataType.STRING, maxStr);
+                        if (vaultColorName != null) {
+                            pdc.set(VAULT_COLOR_KEY, PersistentDataType.STRING, vaultColorName);
+                        }
+                    } else {
+                        pdc.set(MARKER_TYPE_KEY, PersistentDataType.STRING, MT_BOUND_FRAME);
+                    }
+                });
+            } catch (Exception e) {
+                plugin.getLogger().log(Level.WARNING, "Failed to spawn bound frame entity", e);
+            }
+            isFirstEntity = false;
+        }
+
+        String colorLabel = (vaultColor != null) ? " (" + vaultColor.name() + ")" : "";
+        String displayName = MT_VAULT_DOOR.equals(markerType) ? "Vault Door" : "Gate";
+        int width  = (dz <= dx && dz <= dy) ? (maxX - minX + 1) : (maxZ - minZ + 1);
+        int height = maxY - minY + 1;
+        player.sendActionBar(Component.text(
+                "Placed " + displayName + colorLabel
+                + " (" + width + "×" + height + ")", NamedTextColor.GREEN));
+    }
+
+    // -------------------------------------------------------------------------
+    // Generic point marker placement
+    // -------------------------------------------------------------------------
+
+    /**
+     * Places a single small BlockDisplay as a point marker.
+     *
+     * @param event      The interact event.
+     * @param player     The builder.
+     * @param markerType MARKER_TYPE_KEY value.
+     * @param material   The block material to display.
+     * @param scale      Uniform scale factor.
+     * @param color      Optional VaultColor (stored if non-null).
+     * @param coinValue  Coin value to store (-1 to skip).
+     */
+    private void placePointMarker(PlayerInteractEvent event, Player player,
+                                  String markerType, Material material, float scale,
+                                  @Nullable VaultColor color, int coinValue) {
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK
+                || event.getClickedBlock() == null
+                || event.getBlockFace() == null) {
+            player.sendActionBar(Component.text("Right-click a block face to place.", NamedTextColor.YELLOW));
+            return;
+        }
+
+        Block airBlock = event.getClickedBlock().getRelative(event.getBlockFace());
+        if (!airBlock.getType().isAir()) {
+            player.sendActionBar(Component.text("Space is occupied.", NamedTextColor.RED));
+            return;
+        }
+
+        // Offset by (0.5 - scale/2) to centre the small block within the block space
+        float offset = (1.0f - scale) / 2.0f;
+        Location spawnLoc = airBlock.getLocation().clone().add(0.5, 0, 0.5);
+        BlockData blockData = material.createBlockData();
+        final String colorName = (color != null) ? color.name() : null;
+        final int finalCoinValue = coinValue;
+
+        try {
+            player.getWorld().spawn(spawnLoc, BlockDisplay.class, display -> {
+                display.setBlock(blockData);
+                display.setGravity(false);
+                display.setInvulnerable(true);
+                display.setPersistent(true);
+                display.setTransformation(new Transformation(
+                        new Vector3f(offset, offset, offset),
+                        new AxisAngle4f(0f, 0f, 0f, 1f),
+                        new Vector3f(scale, scale, scale),
+                        new AxisAngle4f(0f, 0f, 0f, 1f)
+                ));
                 PersistentDataContainer pdc = display.getPersistentDataContainer();
-                pdc.set(MARKER_TYPE_KEY, PersistentDataType.STRING, "ENTRYPOINT");
-                pdc.set(DIRECTION_KEY, PersistentDataType.STRING, directionToPlace.name()); // Store initial direction
-                pdc.set(BUILD_MARKER_TAG, PersistentDataType.BYTE, (byte)1);
+                pdc.set(BUILD_MARKER_TAG, PersistentDataType.BYTE, (byte) 1);
+                pdc.set(MARKER_TYPE_KEY, PersistentDataType.STRING, markerType);
+                if (colorName != null) {
+                    pdc.set(VAULT_COLOR_KEY, PersistentDataType.STRING, colorName);
+                }
+                if (finalCoinValue > 0) {
+                    pdc.set(COIN_VALUE_KEY, PersistentDataType.INTEGER, finalCoinValue);
+                }
             });
 
-            player.sendActionBar(Component.text("Placed Entry Point Marker (" + directionToPlace.name() + ").", NamedTextColor.GREEN));
+            String colorLabel = (color != null) ? " (" + color.name() + ")" : "";
+            String valueSuffix = (coinValue > 0) ? " value=" + coinValue : "";
+            player.sendActionBar(Component.text(
+                    "Placed " + markerType + colorLabel + valueSuffix, NamedTextColor.GREEN));
 
         } catch (Exception e) {
-            plugin.getLogger().log(Level.SEVERE, "Failed to spawn marker ItemDisplay for entry point", e);
+            plugin.getLogger().log(Level.SEVERE, "Failed to spawn point marker: " + markerType, e);
             player.sendMessage(Component.text("Error placing marker entity.", NamedTextColor.RED));
         }
     }
 
-     /**
-      * Rotates an existing entry point marker entity to the next cardinal direction.
-      * @param player The player triggering the rotation.
-      * @param display The ItemDisplay entity representing the entry point marker.
-      */
-     private void rotateEntryPointMarker(Player player, ItemDisplay display) {
-         PersistentDataContainer pdc = display.getPersistentDataContainer();
-         // Redundant check if filter works, but safe
-         if (!"ENTRYPOINT".equals(pdc.get(MARKER_TYPE_KEY, PersistentDataType.STRING))) return;
+    // -------------------------------------------------------------------------
+    // Left-click: remove any marker
+    // -------------------------------------------------------------------------
 
-         String currentDirStr = pdc.get(DIRECTION_KEY, PersistentDataType.STRING);
-         Direction currentDirection;
-         try {
-             currentDirection = (currentDirStr != null) ? Direction.valueOf(currentDirStr) : Direction.NORTH;
-         } catch (IllegalArgumentException e) { currentDirection = Direction.NORTH; }
+    private void handleLeftClick(Player player) {
+        Predicate<Entity> filter = e ->
+                e instanceof BlockDisplay
+                && e.getPersistentDataContainer().has(BUILD_MARKER_TAG, PersistentDataType.BYTE);
 
-         // Cycle through cardinal directions: N -> E -> S -> W -> N
-         Direction nextDirection;
-         switch (currentDirection) {
-             case NORTH: nextDirection = Direction.EAST; break;
-             case EAST:  nextDirection = Direction.SOUTH; break;
-             case SOUTH: nextDirection = Direction.WEST; break;
-             case WEST:
-             default:    nextDirection = Direction.NORTH; break;
-         }
+        RayTraceResult ray = player.getWorld().rayTraceEntities(
+                player.getEyeLocation(), player.getEyeLocation().getDirection(), 6.0, filter);
 
-         // Update PDC
-         pdc.set(DIRECTION_KEY, PersistentDataType.STRING, nextDirection.name());
+        if (ray == null || ray.getHitEntity() == null) {
+            player.sendActionBar(Component.text("No marker in sight.", NamedTextColor.GRAY));
+            return;
+        }
 
-         // Update Transformation
-         AxisAngle4f newRotation = calculateRotationForDirection(nextDirection);
-         
-         Transformation currentTransform = display.getTransformation();
-         // Create new transformation keeping scale/translation, only changing rotation
-         Quaternionf quaternionRotation = new Quaternionf(newRotation);
+        Entity hit = ray.getHitEntity();
+        PersistentDataContainer pdc = hit.getPersistentDataContainer();
+        String markerType = pdc.getOrDefault(MARKER_TYPE_KEY, PersistentDataType.STRING, "Unknown");
 
-        // Create the new Transformation object
-        Transformation newTransform = new Transformation(
-            currentTransform.getTranslation(),
-            quaternionRotation, // Use the converted Quaternionf
-            currentTransform.getScale(),
-            currentTransform.getRightRotation()
-        );
+        // If this entity belongs to a group (entry point frame or bound frame), remove all of them
+        String groupId = pdc.get(BOUND_GROUP_KEY, PersistentDataType.STRING);
+        if (groupId != null && !groupId.isEmpty()) {
+            int removed = removeGroupEntities(groupId, hit.getWorld());
+            player.sendActionBar(Component.text(
+                    "Removed " + markerType + " marker group (" + removed + " entities).",
+                    NamedTextColor.YELLOW));
+        } else {
+            hit.remove();
+            player.sendActionBar(Component.text("Removed " + markerType + " marker.", NamedTextColor.YELLOW));
+        }
+    }
 
-        // Apply the new transformation
-        display.setTransformation(newTransform);
-         display.setTransformation(newTransform);
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
 
-         player.sendActionBar(Component.text("Rotated Entry Point Marker to " + nextDirection.name(), NamedTextColor.YELLOW));
-     }
-
-     /** Calculates the Y-axis rotation for an ItemDisplay arrow to face a direction. */
-     private AxisAngle4f calculateRotationForDirection(Direction direction) {
-          float yaw = 0f; // Default: South
-          switch (direction) {
-              case NORTH: yaw = 180f; break;
-              case EAST:  yaw = -90f; break;
-              case WEST:  yaw = 90f;  break;
-              case SOUTH: yaw = 0f;   break;
-              // UP/DOWN would need X/Z rotation, not handled here
-            default:
-                break;
-          }
-          // Rotation around Y axis
-          return new AxisAngle4f((float) Math.toRadians(yaw), 0f, 1f, 0f);
-     }
-
-
-     /** Helper to calculate placement location */
-     private Location calculatePlacementLocation(Player player, Block clickedBlock, BlockFace clickedFace, double yOffset) {
-        // ... (Implementation remains the same) ...
-         Location spawnLocation;
-         Location eyeLoc = player.getEyeLocation();
-         if (clickedBlock != null && clickedFace != null) {
-             Block potentialBlock = clickedBlock.getRelative(clickedFace);
-             if (!potentialBlock.getType().isSolid() || potentialBlock.isLiquid()) {
-                 spawnLocation = potentialBlock.getLocation().add(0.5, 0, 0.5);
-                 spawnLocation.setY(potentialBlock.getY() + yOffset);
-             } else {
-                 spawnLocation = eyeLoc.clone().add(player.getFacing().getDirection().multiply(1.5));
-                 spawnLocation.setY(Math.floor(spawnLocation.getY()) + yOffset);
-             }
-         } else {
-             spawnLocation = eyeLoc.clone().add(player.getFacing().getDirection().multiply(1.5));
-             spawnLocation.setY(Math.floor(spawnLocation.getY()) + yOffset);
-         }
-         spawnLocation.setPitch(0);
-         spawnLocation.setYaw(player.getLocation().getYaw());
-         return spawnLocation;
-     }
-
+    /**
+     * Removes all BUILD_MARKER_TAG entities in the world that share the given group ID.
+     * @return number of entities removed.
+     */
+    private int removeGroupEntities(String groupId, org.bukkit.World world) {
+        List<Entity> toRemove = new ArrayList<>();
+        for (Entity e : world.getEntities()) {
+            if (e instanceof BlockDisplay
+                    && e.getPersistentDataContainer().has(BUILD_MARKER_TAG, PersistentDataType.BYTE)
+                    && groupId.equals(e.getPersistentDataContainer().get(BOUND_GROUP_KEY, PersistentDataType.STRING))) {
+                toRemove.add(e);
+            }
+        }
+        toRemove.forEach(Entity::remove);
+        return toRemove.size();
+    }
 }

--- a/src/main/java/com/clarkson/sot/main/SoT.java
+++ b/src/main/java/com/clarkson/sot/main/SoT.java
@@ -21,7 +21,8 @@ import com.clarkson.sot.utils.StructureLoader;
 import com.clarkson.sot.utils.TeamManager;
 // Import Commands
 import com.clarkson.sot.commands.*;
-// Import Listeners
+// Import Listeners / Session management
+import com.clarkson.sot.events.BuilderSessionManager;
 import com.clarkson.sot.events.ToolListener;
 // Import Entities if needed for static init
 import com.clarkson.sot.entities.CoinStack;
@@ -30,7 +31,7 @@ import com.clarkson.sot.entities.CoinStack;
 public class SoT extends JavaPlugin {
 
     // --- Instance Variables for Managers ---
-    private GameManager gameManager; // Must be initialized first
+    private GameManager gameManager;
     private TeamManager teamManager;
     private PlayerStateManager playerStateManager;
     private StructureLoader structureLoader;
@@ -39,7 +40,7 @@ public class SoT extends JavaPlugin {
     private ScoreManager scoreManager;
     private SandManager sandManager;
     private BankingManager bankingManager;
-    // Add others as needed
+    private BuilderSessionManager builderSessionManager;
 
     @Override
     public void onEnable() {
@@ -100,19 +101,21 @@ public class SoT extends JavaPlugin {
         // 4. Initialize static keys if needed
         CoinStack.initializeKeys(this);
 
+        // 5. Builder session manager (shared between ToolListener and SetBuilderModeCommand)
+        builderSessionManager = new BuilderSessionManager();
+
 
         // --- Register Commands ---
-        // Pass necessary managers to commands that need them
-        this.getCommand("sotplacecoindisplay").setExecutor(new PlaceCoinDisplayCommand(this));
-        this.getCommand("sotgetcointool").setExecutor(new GiveCoinToolCommand());
-        this.getCommand("sotgetitemtool").setExecutor(new GiveItemToolCommand(this));
-        this.getCommand("sotgetentrytool").setExecutor(new GiveEntryPointToolCommand(this));
-        // this.getCommand("sotsavesegment").setExecutor(new SaveSegmentCommand(this)); // Needs StructureSaver instance
+        SetBuilderModeCommand modeCmd = new SetBuilderModeCommand(builderSessionManager);
+        this.getCommand("sotbuilder").setExecutor(new GiveBuilderToolCommand(this));
+        this.getCommand("sotmode").setExecutor(modeCmd);
+        this.getCommand("sotmode").setTabCompleter(modeCmd);
+        this.getCommand("sotsavesegment").setExecutor(new SaveSegmentCommand(this));
 
 
         // --- Register Listeners ---
-        getServer().getPluginManager().registerEvents(new ToolListener(this), this);
-        getServer().getPluginManager().registerEvents(vaultManager, this); // VaultManager handles vault interactions
+        getServer().getPluginManager().registerEvents(new ToolListener(this, builderSessionManager), this);
+        getServer().getPluginManager().registerEvents(vaultManager, this);
 
 
         getLogger().info("Sands of Time Enabled Successfully.");

--- a/src/main/java/com/clarkson/sot/utils/StructureLoader.java
+++ b/src/main/java/com/clarkson/sot/utils/StructureLoader.java
@@ -1,10 +1,11 @@
 package com.clarkson.sot.utils;
 
 // Local project imports
-import com.clarkson.sot.dungeon.segment.*; // Import SegmentType
-import com.clarkson.sot.dungeon.VaultColor; // Import VaultColor
+import com.clarkson.sot.dungeon.segment.*;
+import com.clarkson.sot.dungeon.VaultColor;
 import com.clarkson.sot.dungeon.segment.Segment;
 import com.clarkson.sot.dungeon.segment.Segment.RelativeEntryPoint;
+import com.clarkson.sot.dungeon.segment.SegmentBound;
 
 // WorldEdit imports
 import com.sk89q.worldedit.math.BlockVector3;
@@ -12,7 +13,8 @@ import com.sk89q.worldedit.math.BlockVector3;
 // Gson imports
 import com.google.gson.*;
 import org.bukkit.plugin.Plugin;
-import org.jetbrains.annotations.Nullable; // For nullable checks
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 // Java IO and Util
 import java.io.File;
@@ -163,24 +165,48 @@ public class StructureLoader {
                  keyLocationOffset = deserializeBlockVector3(json.getAsJsonObject("keyLocationOffset"), "keyLocationOffset", name, sourceFileName);
             }
 
+            // --- Deserialize new fields ---
+            SegmentBound vaultDoorBound = null;
+            if (json.has("vaultDoorBound") && json.get("vaultDoorBound").isJsonObject()) {
+                vaultDoorBound = deserializeSegmentBound(
+                        json.getAsJsonObject("vaultDoorBound"), "vaultDoorBound", name, sourceFileName);
+            }
+
+            List<SegmentBound> gates = deserializeSegmentBoundList(
+                    json.getAsJsonArray("gates"), "gates", name, sourceFileName);
+
+            BlockVector3 leverOffset = null;
+            if (json.has("leverOffset") && json.get("leverOffset").isJsonObject()) {
+                leverOffset = deserializeBlockVector3(
+                        json.getAsJsonObject("leverOffset"), "leverOffset", name, sourceFileName);
+            }
+
+            List<BlockVector3> sandSacrifices = deserializeBlockVectorList(
+                    json.getAsJsonArray("sandSacrificeLocations"), "sandSacrificeLocations", name, sourceFileName);
+            List<BlockVector3> mobSpawners = deserializeBlockVectorList(
+                    json.getAsJsonArray("mobSpawnerLocations"), "mobSpawnerLocations", name, sourceFileName);
+
             // --- Construct the Segment Template Object ---
-            // Ensure this call matches the LATEST Segment constructor signature EXACTLY
             return new Segment(
                     name,
-                    type, // Pass the parsed SegmentType
+                    type,
                     schematicFileName,
                     size,
-                    // Provide empty lists if deserialization returned null (though helpers return empty lists now)
                     entryPoints != null ? entryPoints : new ArrayList<>(),
-                    sandSpawns != null ? sandSpawns : new ArrayList<>(),
-                    itemSpawns != null ? itemSpawns : new ArrayList<>(),
-                    coinSpawns != null ? coinSpawns : new ArrayList<>(),
-                    totalCoins != null ? totalCoins : 0, // Default totalCoins to 0 if missing/invalid
-                    // Removed arguments for: coinMultiplier, isHub, isPuzzleRoom, isLavaParkour
-                    containedVault,      // Can be null
-                    containedVaultKey,   // Can be null
-                    vaultLocationOffset, // Can be null
-                    keyLocationOffset    // Can be null
+                    sandSpawns  != null ? sandSpawns  : new ArrayList<>(),
+                    itemSpawns  != null ? itemSpawns  : new ArrayList<>(),
+                    coinSpawns  != null ? coinSpawns  : new ArrayList<>(),
+                    totalCoins  != null ? totalCoins  : 0,
+                    containedVault,
+                    containedVaultKey,
+                    vaultLocationOffset,
+                    keyLocationOffset,
+                    // New fields
+                    vaultDoorBound,
+                    gates  != null ? gates  : new ArrayList<>(),
+                    leverOffset,
+                    sandSacrifices != null ? sandSacrifices : new ArrayList<>(),
+                    mobSpawners    != null ? mobSpawners    : new ArrayList<>()
             );
 
         } catch (JsonParseException | IllegalStateException | ClassCastException | NullPointerException e) {
@@ -311,6 +337,44 @@ public class StructureLoader {
             } // Error logged in deserializeBlockVector3 if null
         }
         return vectors;
+    }
+
+    /**
+     * Deserializes a JSON object into a SegmentBound.
+     * Expected format: {"min": {"x": X, "y": Y, "z": Z}, "max": {"x": X, "y": Y, "z": Z}}
+     */
+    @Nullable
+    private SegmentBound deserializeSegmentBound(@Nullable JsonObject boundJson,
+                                                  String context, String segmentName, String sourceFileName) {
+        if (boundJson == null) return null;
+        BlockVector3 min = deserializeBlockVector3(boundJson.get("min"), context + ".min", segmentName, sourceFileName);
+        BlockVector3 max = deserializeBlockVector3(boundJson.get("max"), context + ".max", segmentName, sourceFileName);
+        if (min == null || max == null) {
+            plugin.getLogger().warning("[StructureLoader] Incomplete SegmentBound for " + context
+                    + " in '" + segmentName + "' from " + sourceFileName);
+            return null;
+        }
+        return new SegmentBound(min, max);
+    }
+
+    /**
+     * Deserializes a JSON array of SegmentBound objects.
+     */
+    @NotNull
+    private List<SegmentBound> deserializeSegmentBoundList(@Nullable JsonElement arrayElement,
+                                                            String listName, String segmentName, String sourceFileName) {
+        List<SegmentBound> bounds = new ArrayList<>();
+        if (arrayElement == null || !arrayElement.isJsonArray()) return bounds;
+        JsonArray arr = arrayElement.getAsJsonArray();
+        for (int i = 0; i < arr.size(); i++) {
+            JsonElement el = arr.get(i);
+            if (el != null && el.isJsonObject()) {
+                SegmentBound bound = deserializeSegmentBound(el.getAsJsonObject(),
+                        listName + "[" + i + "]", segmentName, sourceFileName);
+                if (bound != null) bounds.add(bound);
+            }
+        }
+        return bounds;
     }
 
     /**

--- a/src/main/java/com/clarkson/sot/utils/StructureSaver.java
+++ b/src/main/java/com/clarkson/sot/utils/StructureSaver.java
@@ -1,11 +1,12 @@
 package com.clarkson.sot.utils;
 
 // Local project imports
-import com.clarkson.sot.dungeon.segment.*; // Import SegmentType if needed by Segment
-import com.clarkson.sot.dungeon.VaultColor; // Import VaultColor if needed by Segment
+import com.clarkson.sot.dungeon.segment.*;
+import com.clarkson.sot.dungeon.VaultColor;
 import com.clarkson.sot.dungeon.segment.PlacedSegment;
 import com.clarkson.sot.dungeon.segment.Segment;
 import com.clarkson.sot.dungeon.segment.Segment.RelativeEntryPoint;
+import com.clarkson.sot.dungeon.segment.SegmentBound;
 
 // WorldEdit imports
 import com.sk89q.worldedit.EditSession;
@@ -343,6 +344,24 @@ public class StructureSaver {
                 json.add("keyLocationOffset", serializeBlockVector3(keyOffset));
             }
 
+            // --- Serialize new door / gate / lever / extra spawn fields ---
+            SegmentBound vaultDoor = segmentTemplate.getVaultDoorBound();
+            if (vaultDoor != null) {
+                json.add("vaultDoorBound", serializeSegmentBound(vaultDoor));
+            }
+
+            json.add("gates", serializeSegmentBoundList(segmentTemplate.getGates()));
+
+            BlockVector3 lever = segmentTemplate.getLeverOffset();
+            if (lever != null) {
+                json.add("leverOffset", serializeBlockVector3(lever));
+            }
+
+            json.add("sandSacrificeLocations", serializeBlockVectorList(
+                    segmentTemplate.getSandSacrificeLocations(), "sandSacrificeLocations", segmentName));
+            json.add("mobSpawnerLocations", serializeBlockVectorList(
+                    segmentTemplate.getMobSpawnerLocations(), "mobSpawnerLocations", segmentName));
+
             return json;
 
         } catch (Exception e) {
@@ -392,6 +411,24 @@ public class StructureSaver {
             }
         }
         return jsonArray;
+    }
+
+    private JsonObject serializeSegmentBound(@Nullable SegmentBound bound) {
+        if (bound == null) return null;
+        JsonObject obj = new JsonObject();
+        obj.add("min", serializeBlockVector3(bound.getMin()));
+        obj.add("max", serializeBlockVector3(bound.getMax()));
+        return obj;
+    }
+
+    private JsonArray serializeSegmentBoundList(@Nullable List<SegmentBound> bounds) {
+        JsonArray arr = new JsonArray();
+        if (bounds != null) {
+            for (SegmentBound b : bounds) {
+                if (b != null) arr.add(serializeSegmentBound(b));
+            }
+        }
+        return arr;
     }
 
     // sanitizeFileName remains the same

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,70 +1,49 @@
 name: SoT
-version: '${project.version}' # Uses version from pom.xml
+version: '${project.version}'
 main: com.clarkson.sot.main.SoT
-api-version: '1.21' # <-- Updated to match target server/Java version
-depend: [WorldEdit] # Declare WorldEdit dependency
-loadbefore: [] # Optional: Add plugins that should load AFTER this one
-authors: [ZacClarkson] # Use list format for authors
+api-version: '1.21'
+depend: [WorldEdit]
+authors: [ZacClarkson]
 description: A minecraft game based on MCC
 
 commands:
-  # --- Builder Tool Commands ---
-  sotplacecoindisplay: # <-- Added definition
-    description: Spawns a visual coin stack display for segment building.
-    usage: /<command> <value>
-    permission: sot.admin.placedisplay
-  sotgetcointool:
-    description: Gives the player a tool to place Coin Displays.
-    usage: /<command> <value>
-    permission: sot.admin.givetool
-  sotgetitemtool: # <-- Added definition
-    description: Gives the player a tool to place Item Spawn markers.
+
+  # --- Segment Builder Tool ---
+  sotbuilder:
+    description: Gives the single master segment builder tool (BLAZE_ROD).
     usage: /<command>
-    permission: sot.admin.givetool # Reusing permission
-  sotgetentrytool: # <-- Added definition
-    description: Gives the player a tool to place Entry Point markers.
-    usage: /<command>
-    permission: sot.admin.givetool # Reusing permission
+    permission: sot.admin.builder
+
+  sotmode:
+    description: Switches the segment builder tool mode.
+    usage: /<command> <mode> [color|value]
+    permission: sot.admin.builder
+
   sotsavesegment:
     description: Saves the selected WorldEdit region as a new SoT segment template.
-    usage: /<command> <name> <type> <schematic_filename> [totalCoins]
+    usage: /<command> <name> <type>
     permission: sot.admin.savesegment
 
-  # --- Game Control Commands (Examples - Implement these) ---
+  # --- Game Control Commands (implement as needed) ---
   # sot:
-    # description: Main command for Sands of Time game control.
-    # usage: /<command> <setup|start|end|set> ...
-    # permission: sot.admin.control
-    # aliases: [sandsoftime] # Optional aliases
-  # team:
-    # description: Command for team assignments.
-    # usage: /<command> assign <player> <TeamID>
-    # permission: sot.admin.team
+  #   description: Main command for Sands of Time game control.
+  #   usage: /<command> <setup|start|end|set> ...
+  #   permission: sot.admin.control
 
 permissions:
-  sot.admin.givetool:
-    description: Allows getting the SoT builder tools (coin, item, entry point). # <-- Updated description
-    default: op
-  sot.admin.placedisplay:
-    description: Allows placing visual coin displays for building using the tool.
-    default: op
-  sot.admin.placeitemspawn:
-    description: Allows placing item spawn markers for building using the tool.
-    default: op
-  sot.admin.placeentrypoint: # <-- Added definition
-    description: Allows placing entry point markers for building using the tool.
-    default: op
-  sot.admin.removemarker:
-    description: Allows removing SoT builder markers with left-click using a tool.
-    default: op
-  sot.admin.savesegment:
-    description: Allows saving new SoT segments.
-    default: op
-  sot.admin.control: # Example permission for game control
-    description: Allows controlling the SoT game state (setup, start, end, set).
-    default: op
-  sot.admin.team: # Example permission for team command
-    description: Allows managing SoT team assignments.
+
+  sot.admin.builder:
+    description: Allows using the segment builder tool and switching modes.
     default: op
 
-# ... potentially other plugin.yml sections like loadbefore/softdepend ...
+  sot.admin.savesegment:
+    description: Allows saving new SoT segment templates.
+    default: op
+
+  sot.admin.control:
+    description: Allows controlling the SoT game state (setup, start, end).
+    default: op
+
+  sot.admin.team:
+    description: Allows managing SoT team assignments.
+    default: op


### PR DESCRIPTION
## Summary

- **Single master builder tool** (`/sotbuilder`) replaces old per-feature tools. Mode switched with `/sotmode <mode> [color|value]`.
- **11 builder modes**: `ENTRY_POINT`, `VAULT_DOOR`, `VAULT_MARKER`, `KEY_SPAWN`, `GATE`, `LEVER`, `SAND_SPAWN`, `SAND_SACRIFICE`, `COIN_SPAWN`, `ITEM_SPAWN`, `MOB_SPAWNER`
- **All markers are `BlockDisplay` entities** — no resource pack needed. Left-click removes any marker. Entry point frames and bound frames are grouped and removed together.
- **Entry point frame**: 2×3 lime stained glass; right-click existing anchor to rotate N→E→S→W.
- **Vault door / Gate**: two-click bound selection, variable size. Purple for vault doors, grey for gates.
- **`/sotsavesegment <name> <type>`**: scans WE selection for all markers, prints summary, validates gate↔lever constraint, auto-derives schem filename.
- **`Segment`, `StructureSaver`, `StructureLoader`** updated for new fields: `vaultDoorBound`, `gates`, `leverOffset`, `sandSacrificeLocations`, `mobSpawnerLocations`.
- **Removed `LAVA_PARKOUR` from `SegmentType`** — gold key room identified by `containedVaultKey == GOLD` alone.

https://claude.ai/code/session_01XHavVtWoCiLMaQ7Rg5VvzS